### PR TITLE
Revert "cmake: reorder lua main libraries to avoid warnings"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,7 +541,7 @@ function(add_lua_executable name main)
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tools/luamain.lua ${main}
   )
   add_executable(${name} ${luamain})
-  target_link_libraries(${name} PRIVATE ${ARGN} elune)
+  target_link_libraries(${name} PRIVATE elune ${ARGN})
 endfunction()
 
 lua2c(wowlessyaml wowapi.yaml=${CMAKE_CURRENT_SOURCE_DIR}/wowapi/yaml.lua)


### PR DESCRIPTION
This reverts commit 1d3e7c2fc3d6fcd75e859f7b729bdf3342d7951c.
