### PR TITLE
start getting wowless back on track

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
         libyaml-dev \
         libzip-dev \
         ninja-build \
-        ruby \
+        ruby-dev \
         tar \
         unzip \
         zip \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         imageName: ghcr.io/wowless/wowless-devcontainer
         refFilterForPush: refs/heads/main
-        runCmd: pre-commit run -a -v && ninja -v all
+        runCmd: pre-commit run -a -v
     - uses: actions/upload-artifact@v3
       if: success() || failure()
       with:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ errors, those errors are almost certainly still in Wowless, not your addon. That
 said, Wowless is undergoing active development. If you're interested, join the
 Discord at <https://discord.gg/rTwWcfJXuz>.
 
+IMPORTANT NOTE: Wowless currently points at product builds that are no longer
+available on the Blizzard CDN. The binary and develop environment are still
+functional. Maintainers are aware and are digging out of this hole. Visit the
+Discord for updates.
+
 Development is currently only supported via Docker.
 
 Using VSCode:


### PR DESCRIPTION
* devcontainer fix for broken markdown pre-commit
* turn off `ninja -v all` in gha for now
* IMPORTANT NOTE in the readme
