### PR TITLE
xmleval: move implicit fontstring/texture anchor hacks out of initKids

### DIFF
--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -116,6 +116,16 @@ return function(
     for _, template in ipairs(tmpls) do
       initKids(template, ud)
     end
+    -- These only apply to template-driven creation (XML authoring convenience
+    -- for anchor-less fontstrings/textures); #tmpls == 0 means a plain
+    -- CreateTexture()/CreateFontString() call, which gets no implicit anchor.
+    if #tmpls > 0 and ud:IsObjectType('fontstring') and ud:GetNumPoints() == 0 then
+      -- Conveniently the JustifyHorizontal names match FramePoint.
+      points.SetPointInternal(ud, ud.justifyh, ud.parent, ud.justifyh, 0, 0)
+    end
+    if #tmpls > 0 and ud:IsObjectType('texture') and ud:GetNumPoints() == 0 then
+      points.SetAllPointsInternal(ud, ud.parent)
+    end
     if id then
       ud:SetID(id)
     end
@@ -685,15 +695,6 @@ return function(
   initKids = makePhaseRunner(function(ctx, e, obj)
     processKids(ctx, e, obj, 'late')
     processAttrs(ctx, e, obj, 'late')
-    -- Implicit setpoint hack for fontstrings.
-    if obj:IsObjectType('fontstring') and obj:GetNumPoints() == 0 then
-      -- Conveniently the JustifyHorizontal names match FramePoint.
-      points.SetPointInternal(obj, obj.justifyh, obj.parent, obj.justifyh, 0, 0)
-    end
-    -- Implicit setallpoints hack for textures.
-    if obj:IsObjectType('texture') and obj:GetNumPoints() == 0 then
-      points.SetAllPointsInternal(obj, obj.parent)
-    end
   end)
 
   function loadElement(ctx, e, parent)


### PR DESCRIPTION
## Summary

Moves the two "implicit setpoint/setallpoints" hacks (default anchors for anchor-less fontstrings/textures declared via templates) out of the per-template `initKids` phase runner and into `CreateUIObject`, so they run exactly once per object instead of once per template in the `inherits=` chain.

This is a real (bugfix-flavored) behavior change, not a pure refactor:
- Before: the hack ran inside every template's Kids phase, checking `GetNumPoints() == 0` immediately after *that* template's Kids phase finished. With multiple templates in a chain, this meant the hack could fire after an early template's Kids phase left the object anchor-less, before a *later* template's own Kids phase got a chance to set a real anchor.
- After: it runs once, after every template in `tmpls` has finished its Kids phase.

Caught a real regression while making this change: `b:CreateTexture()`/`CreateFontString()` calls with no `inherits=` produce an empty `tmpls` list, and `initKids` was never invoked at all in that case (the `for _, template in ipairs(tmpls) do ... end` loop has zero iterations) — so the hack never fired for plain Lua-created textures/fontstrings. Moving the check unconditionally into `CreateUIObject` broke that (caught by `addon/Wowless/test.lua:248`, which asserts a freshly `CreateTexture()`'d texture has 0 points). Fixed by guarding both hacks with `#tmpls > 0`, matching the original precondition — this is XML-authoring-convenience behavior, not a default for bare API calls.

## Test plan
- [x] `cmake --build --preset default --target test` — clean exit, no output (also ran via the `build and test` pre-commit hook)
- [x] `cmake --build --preset default --target outs` — clean exit; all 8 products' `log.txt` empty, verified against the exact pushed commit (confirms the per-template → once-per-object consolidation doesn't change anything observable in the real FrameXML corpus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9fF7diFzcuVVgq6C9zBZ4