### PR TITLE
addon: test whether Create*() uiobject APIs accept multiple templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1053,6 +1053,7 @@ file(MAKE_DIRECTORY ${d} ${CMAKE_CURRENT_BINARY_DIR}/staging/addon/Wowless)
 set(testaddon_outs)
 foreach(
   f
+  apitemplates.xml
   arraydiff.lua
   asynctests.lua
   evenmoreintrinsic.xml
@@ -1062,6 +1063,7 @@ foreach(
   init.lua
   luaobjects.lua
   statemachine.lua
+  templates.lua
   test.lua
   uiobjects.lua
   util.lua

--- a/addon/Wowless/Wowless.toc
+++ b/addon/Wowless/Wowless.toc
@@ -15,5 +15,6 @@ luaobjects.lua
 test.xml
 generated.lua
 uiobjects.lua
+templates.lua
 asynctests.lua
 test.lua

--- a/addon/Wowless/apitemplates.xml
+++ b/addon/Wowless/apitemplates.xml
@@ -76,34 +76,14 @@
     </KeyValues>
   </AnimationGroup>
 
-  <!--
-    Animation and ControlPoint aren't valid top-level template tags, so
-    these are registered as virtual templates nested inside a real (always
-    instantiated) AnimationGroup/Path instead, the same way any other
-    virtual template gets registered when its containing element loads.
-    ControlPoint has no KeyValues support, so offsetx/offsety (readable via
-    GetOffset()) stand in as the per-template markers instead.
-  -->
-  <Frame>
-    <Animations>
-      <AnimationGroup>
-        <Animation name='WowlessApiTemplateAnimation1' virtual='true'>
-          <KeyValues>
-            <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
-          </KeyValues>
-        </Animation>
-        <Animation name='WowlessApiTemplateAnimation2' virtual='true'>
-          <KeyValues>
-            <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
-          </KeyValues>
-        </Animation>
-        <Path>
-          <ControlPoints>
-            <ControlPoint name='WowlessApiTemplateControlPoint1' virtual='true' offsetx='11' />
-            <ControlPoint name='WowlessApiTemplateControlPoint2' virtual='true' offsety='22' />
-          </ControlPoints>
-        </Path>
-      </AnimationGroup>
-    </Animations>
-  </Frame>
+  <Animation name='WowlessApiTemplateAnimation1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </Animation>
+  <Animation name='WowlessApiTemplateAnimation2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </Animation>
 </Ui>

--- a/addon/Wowless/apitemplates.xml
+++ b/addon/Wowless/apitemplates.xml
@@ -1,0 +1,67 @@
+<Ui>
+  <!--
+    Templates used to check whether the various Create*() APIs that take a
+    template/templateName argument accept more than one template name
+    (comma-separated, the way XML inherits= does) or reject/ignore it. See
+    templates.lua.
+  -->
+  <Script>
+    WowlessApiTemplateActorMixin1 = { apiTemplateFrom1 = true }
+    WowlessApiTemplateActorMixin2 = { apiTemplateFrom2 = true }
+  </Script>
+
+  <Frame name='WowlessApiTemplateFrame1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </Frame>
+  <Frame name='WowlessApiTemplateFrame2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </Frame>
+
+  <Actor name='WowlessApiTemplateActor1' virtual='true' mixin='WowlessApiTemplateActorMixin1' />
+  <Actor name='WowlessApiTemplateActor2' virtual='true' mixin='WowlessApiTemplateActorMixin2' />
+
+  <Texture name='WowlessApiTemplateTexture1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </Texture>
+  <Texture name='WowlessApiTemplateTexture2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </Texture>
+  <FontString name='WowlessApiTemplateFontString1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </FontString>
+  <FontString name='WowlessApiTemplateFontString2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </FontString>
+  <Line name='WowlessApiTemplateLine1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </Line>
+  <Line name='WowlessApiTemplateLine2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </Line>
+  <MaskTexture name='WowlessApiTemplateMaskTexture1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </MaskTexture>
+  <MaskTexture name='WowlessApiTemplateMaskTexture2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </MaskTexture>
+</Ui>

--- a/addon/Wowless/apitemplates.xml
+++ b/addon/Wowless/apitemplates.xml
@@ -65,25 +65,9 @@
     </KeyValues>
   </MaskTexture>
 
-  <AnimationGroup name='WowlessApiTemplateAnimationGroup1' virtual='true'>
-    <KeyValues>
-      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
-    </KeyValues>
-  </AnimationGroup>
-  <AnimationGroup name='WowlessApiTemplateAnimationGroup2' virtual='true'>
-    <KeyValues>
-      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
-    </KeyValues>
-  </AnimationGroup>
+  <AnimationGroup name='WowlessApiTemplateAnimationGroup1' virtual='true' looping='REPEAT' />
+  <AnimationGroup name='WowlessApiTemplateAnimationGroup2' virtual='true' looping='BOUNCE' />
 
-  <Animation name='WowlessApiTemplateAnimation1' virtual='true'>
-    <KeyValues>
-      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
-    </KeyValues>
-  </Animation>
-  <Animation name='WowlessApiTemplateAnimation2' virtual='true'>
-    <KeyValues>
-      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
-    </KeyValues>
-  </Animation>
+  <Animation name='WowlessApiTemplateAnimation1' virtual='true' smoothing='IN' />
+  <Animation name='WowlessApiTemplateAnimation2' virtual='true' smoothing='OUT' />
 </Ui>

--- a/addon/Wowless/apitemplates.xml
+++ b/addon/Wowless/apitemplates.xml
@@ -64,4 +64,46 @@
       <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
     </KeyValues>
   </MaskTexture>
+
+  <AnimationGroup name='WowlessApiTemplateAnimationGroup1' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+    </KeyValues>
+  </AnimationGroup>
+  <AnimationGroup name='WowlessApiTemplateAnimationGroup2' virtual='true'>
+    <KeyValues>
+      <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+    </KeyValues>
+  </AnimationGroup>
+
+  <!--
+    Animation and ControlPoint aren't valid top-level template tags, so
+    these are registered as virtual templates nested inside a real (always
+    instantiated) AnimationGroup/Path instead, the same way any other
+    virtual template gets registered when its containing element loads.
+    ControlPoint has no KeyValues support, so offsetx/offsety (readable via
+    GetOffset()) stand in as the per-template markers instead.
+  -->
+  <Frame>
+    <Animations>
+      <AnimationGroup>
+        <Animation name='WowlessApiTemplateAnimation1' virtual='true'>
+          <KeyValues>
+            <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
+          </KeyValues>
+        </Animation>
+        <Animation name='WowlessApiTemplateAnimation2' virtual='true'>
+          <KeyValues>
+            <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
+          </KeyValues>
+        </Animation>
+        <Path>
+          <ControlPoints>
+            <ControlPoint name='WowlessApiTemplateControlPoint1' virtual='true' offsetx='11' />
+            <ControlPoint name='WowlessApiTemplateControlPoint2' virtual='true' offsety='22' />
+          </ControlPoints>
+        </Path>
+      </AnimationGroup>
+    </Animations>
+  </Frame>
 </Ui>

--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -100,9 +100,9 @@ G.testsuite.templates = function()
           local f = CreateFrame('Frame')
           local g = retn(1, f:CreateAnimationGroup(nil, 'WowlessApiTemplateAnimationGroup1'))
           if _G.__wowless then
-            check1(nil, g.apiTemplateFrom1)
+            check1('NONE', (g:GetLooping()))
           else
-            check1(true, g.apiTemplateFrom1)
+            check1('REPEAT', (g:GetLooping()))
           end
         end,
         ['comma-separated templates'] = function()
@@ -110,8 +110,7 @@ G.testsuite.templates = function()
           local names = 'WowlessApiTemplateAnimationGroup1,WowlessApiTemplateAnimationGroup2'
           if _G.__wowless then
             local g = retn(1, f:CreateAnimationGroup(nil, names))
-            check1(nil, g.apiTemplateFrom1)
-            check1(nil, g.apiTemplateFrom2)
+            check1('NONE', (g:GetLooping()))
           else
             check1(false, (pcall(f.CreateAnimationGroup, f, nil, names)))
           end
@@ -128,9 +127,9 @@ G.testsuite.templates = function()
           local ag = CreateFrame('Frame'):CreateAnimationGroup()
           local a = retn(1, ag:CreateAnimation('Animation', nil, 'WowlessApiTemplateAnimation1'))
           if _G.__wowless then
-            check1(nil, a.apiTemplateFrom1)
+            check1('NONE', (a:GetSmoothing()))
           else
-            check1(true, a.apiTemplateFrom1)
+            check1('IN', (a:GetSmoothing()))
           end
         end,
         ['comma-separated templates'] = function()
@@ -138,8 +137,7 @@ G.testsuite.templates = function()
           local names = 'WowlessApiTemplateAnimation1,WowlessApiTemplateAnimation2'
           if _G.__wowless then
             local a = retn(1, ag:CreateAnimation('Animation', nil, names))
-            check1(nil, a.apiTemplateFrom1)
-            check1(nil, a.apiTemplateFrom2)
+            check1('NONE', (a:GetSmoothing()))
           else
             check1(false, (pcall(ag.CreateAnimation, ag, 'Animation', nil, names)))
           end

--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -1,0 +1,143 @@
+local _, G = ...
+G.testsuite.templates = function()
+  local assertEquals = G.assertEquals
+  local check1 = G.check1
+  local retn = G.retn
+
+  local function checkBoth(obj)
+    check1(true, obj.apiTemplateFrom1)
+    check1(true, obj.apiTemplateFrom2)
+  end
+
+  return {
+    -- CreateFrame splits its template argument on commas and/or spaces
+    -- (wowless/modules/api.lua), applying every named template in order.
+    CreateFrame = function()
+      return {
+        ['single template'] = function()
+          local f = retn(1, CreateFrame('Frame', nil, nil, 'WowlessApiTemplateFrame1'))
+          check1(true, f.apiTemplateFrom1)
+        end,
+        ['comma-separated templates'] = function()
+          checkBoth(retn(1, CreateFrame('Frame', nil, nil, 'WowlessApiTemplateFrame1,WowlessApiTemplateFrame2')))
+        end,
+        ['comma-space-separated templates'] = function()
+          checkBoth(retn(1, CreateFrame('Frame', nil, nil, 'WowlessApiTemplateFrame1, WowlessApiTemplateFrame2')))
+        end,
+      }
+    end,
+
+    -- CreateForbiddenFrame currently just delegates straight to CreateFrame
+    -- (see wowless/modules/api.lua, "-- TODO implement properly"), so it
+    -- exercises the same comma-splitting behavior for now.
+    CreateForbiddenFrame = function()
+      return {
+        ['comma-separated templates'] = function()
+          local f =
+            retn(1, _G.CreateForbiddenFrame('Frame', nil, nil, 'WowlessApiTemplateFrame1,WowlessApiTemplateFrame2'))
+          checkBoth(f)
+        end,
+      }
+    end,
+
+    -- Frame:CreateTexture/CreateFontString/CreateLine/CreateMaskTexture all
+    -- go through api.CreateChildUIObject, which splits templateName the
+    -- same way CreateFrame does. Real-client testing has shown that
+    -- CreateTexture rejects a comma-separated templateName outright, so
+    -- this is a known wowless/real-client divergence, not just a
+    -- hypothetical one.
+    CreateTexture = function()
+      return {
+        ['comma-separated templates'] = function()
+          local f = CreateFrame('Frame')
+          local t = retn(1, f:CreateTexture(nil, nil, 'WowlessApiTemplateTexture1,WowlessApiTemplateTexture2'))
+          checkBoth(t)
+        end,
+      }
+    end,
+
+    CreateFontString = function()
+      return {
+        ['comma-separated templates'] = function()
+          local f = CreateFrame('Frame')
+          local fs =
+            retn(1, f:CreateFontString(nil, nil, 'WowlessApiTemplateFontString1,WowlessApiTemplateFontString2'))
+          checkBoth(fs)
+        end,
+      }
+    end,
+
+    CreateLine = function()
+      return {
+        ['comma-separated templates'] = function()
+          local f = CreateFrame('Frame')
+          local l = retn(1, f:CreateLine(nil, nil, 'WowlessApiTemplateLine1,WowlessApiTemplateLine2'))
+          checkBoth(l)
+        end,
+      }
+    end,
+
+    CreateMaskTexture = function()
+      return {
+        ['comma-separated templates'] = function()
+          local f = CreateFrame('Frame')
+          local m =
+            retn(1, f:CreateMaskTexture(nil, nil, 'WowlessApiTemplateMaskTexture1,WowlessApiTemplateMaskTexture2'))
+          checkBoth(m)
+        end,
+      }
+    end,
+
+    -- Region/CreateAnimationGroup.lua ignores every argument beyond self
+    -- (it doesn't even accept a name), so the templateName the yaml
+    -- documents is not wired up at all yet -- comma-separated or not.
+    CreateAnimationGroup = function()
+      return {
+        ['comma-separated templates do not error'] = function()
+          local g = retn(1, CreateFrame('Frame'):CreateAnimationGroup('Bogus1,Bogus2'))
+          assertEquals('AnimationGroup', g:GetObjectType())
+        end,
+      }
+    end,
+
+    -- AnimationGroup/CreateAnimation.lua only reads its first argument
+    -- (animationType); name and templateName are accepted but discarded.
+    CreateAnimation = function()
+      return {
+        ['comma-separated templates do not error'] = function()
+          local ag = CreateFrame('Frame'):CreateAnimationGroup()
+          local a = retn(1, ag:CreateAnimation('Animation', nil, 'Bogus1,Bogus2'))
+          assertEquals('Animation', a:GetObjectType())
+        end,
+      }
+    end,
+
+    -- Path/CreateControlPoint.lua reads name but discards templateName.
+    CreateControlPoint = function()
+      return {
+        ['comma-separated templates do not error'] = function()
+          local path = retn(1, CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path'))
+          local point = retn(1, path:CreateControlPoint(nil, 'Bogus1,Bogus2'))
+          assertEquals('ControlPoint', point:GetObjectType())
+        end,
+      }
+    end,
+
+    -- ModelScene/CreateActor.lua looks up its template argument as a
+    -- single literal name (no splitting), so a comma-separated list is
+    -- just an unknown template name and errors.
+    CreateActor = function()
+      return {
+        ['single template'] = function()
+          local scene = retn(1, CreateFrame('ModelScene'))
+          local actor = retn(1, scene:CreateActor(nil, 'WowlessApiTemplateActor1'))
+          check1(true, actor.apiTemplateFrom1)
+        end,
+        ['comma-separated templates error'] = function()
+          local scene = retn(1, CreateFrame('ModelScene'))
+          check1(false, (pcall(scene.CreateActor, scene, nil, 'WowlessApiTemplateActor1,WowlessApiTemplateActor2')))
+        end,
+      }
+    end,
+  }
+end

--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -1,7 +1,6 @@
 local _, G = ...
 G.testsuite.templates = function()
   local check1 = G.check1
-  local check2 = G.check2
   local retn = G.retn
 
   local function checkBoth(obj)
@@ -99,7 +98,7 @@ G.testsuite.templates = function()
       return {
         ['single template'] = function()
           local f = CreateFrame('Frame')
-          local g = retn(1, f:CreateAnimationGroup('WowlessApiTemplateAnimationGroup1'))
+          local g = retn(1, f:CreateAnimationGroup(nil, 'WowlessApiTemplateAnimationGroup1'))
           if _G.__wowless then
             check1(nil, g.apiTemplateFrom1)
           else
@@ -110,11 +109,11 @@ G.testsuite.templates = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateAnimationGroup1,WowlessApiTemplateAnimationGroup2'
           if _G.__wowless then
-            local g = retn(1, f:CreateAnimationGroup(names))
+            local g = retn(1, f:CreateAnimationGroup(nil, names))
             check1(nil, g.apiTemplateFrom1)
             check1(nil, g.apiTemplateFrom2)
           else
-            check1(false, (pcall(f.CreateAnimationGroup, f, names)))
+            check1(false, (pcall(f.CreateAnimationGroup, f, nil, names)))
           end
         end,
       }
@@ -143,33 +142,6 @@ G.testsuite.templates = function()
             check1(nil, a.apiTemplateFrom2)
           else
             check1(false, (pcall(ag.CreateAnimation, ag, 'Animation', nil, names)))
-          end
-        end,
-      }
-    end,
-
-    -- Path/CreateControlPoint.lua reads name but discards templateName,
-    -- so not even a single valid template name is applied (offsetx/offsety
-    -- stay at their 0 defaults instead of the template's values).
-    CreateControlPoint = function()
-      return {
-        ['single template'] = function()
-          local path = retn(1, CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path'))
-          local point = retn(1, path:CreateControlPoint(nil, 'WowlessApiTemplateControlPoint1'))
-          if _G.__wowless then
-            check2(0, 0, point:GetOffset())
-          else
-            check2(11, 0, point:GetOffset())
-          end
-        end,
-        ['comma-separated templates'] = function()
-          local path = retn(1, CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path'))
-          local names = 'WowlessApiTemplateControlPoint1,WowlessApiTemplateControlPoint2'
-          if _G.__wowless then
-            local point = retn(1, path:CreateControlPoint(nil, names))
-            check2(0, 0, point:GetOffset())
-          else
-            check1(false, (pcall(path.CreateControlPoint, path, nil, names)))
           end
         end,
       }

--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -1,7 +1,7 @@
 local _, G = ...
 G.testsuite.templates = function()
-  local assertEquals = G.assertEquals
   local check1 = G.check1
+  local check2 = G.check2
   local retn = G.retn
 
   local function checkBoth(obj)
@@ -12,6 +12,9 @@ G.testsuite.templates = function()
   return {
     -- CreateFrame splits its template argument on commas and/or spaces
     -- (wowless/modules/api.lua), applying every named template in order.
+    -- Confirmed against a real client to work the same way.
+    -- CreateForbiddenFrame is not addon-accessible, so it isn't tested
+    -- separately; assume it behaves like CreateFrame.
     CreateFrame = function()
       return {
         ['single template'] = function()
@@ -27,31 +30,22 @@ G.testsuite.templates = function()
       }
     end,
 
-    -- CreateForbiddenFrame currently just delegates straight to CreateFrame
-    -- (see wowless/modules/api.lua, "-- TODO implement properly"), so it
-    -- exercises the same comma-splitting behavior for now.
-    CreateForbiddenFrame = function()
-      return {
-        ['comma-separated templates'] = function()
-          local f =
-            retn(1, _G.CreateForbiddenFrame('Frame', nil, nil, 'WowlessApiTemplateFrame1,WowlessApiTemplateFrame2'))
-          checkBoth(f)
-        end,
-      }
-    end,
-
     -- Frame:CreateTexture/CreateFontString/CreateLine/CreateMaskTexture all
     -- go through api.CreateChildUIObject, which splits templateName the
-    -- same way CreateFrame does. Real-client testing has shown that
-    -- CreateTexture rejects a comma-separated templateName outright, so
-    -- this is a known wowless/real-client divergence, not just a
-    -- hypothetical one.
+    -- same way CreateFrame does. Confirmed against a real client that this
+    -- is wrong for all four: the client treats the whole templateName
+    -- string as one literal name, so a comma-separated list just fails to
+    -- match any template and errors.
     CreateTexture = function()
       return {
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
-          local t = retn(1, f:CreateTexture(nil, nil, 'WowlessApiTemplateTexture1,WowlessApiTemplateTexture2'))
-          checkBoth(t)
+          local names = 'WowlessApiTemplateTexture1,WowlessApiTemplateTexture2'
+          if _G.__wowless then
+            checkBoth(retn(1, f:CreateTexture(nil, nil, names)))
+          else
+            check1(false, (pcall(f.CreateTexture, f, nil, nil, names)))
+          end
         end,
       }
     end,
@@ -60,9 +54,12 @@ G.testsuite.templates = function()
       return {
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
-          local fs =
-            retn(1, f:CreateFontString(nil, nil, 'WowlessApiTemplateFontString1,WowlessApiTemplateFontString2'))
-          checkBoth(fs)
+          local names = 'WowlessApiTemplateFontString1,WowlessApiTemplateFontString2'
+          if _G.__wowless then
+            checkBoth(retn(1, f:CreateFontString(nil, nil, names)))
+          else
+            check1(false, (pcall(f.CreateFontString, f, nil, nil, names)))
+          end
         end,
       }
     end,
@@ -71,8 +68,12 @@ G.testsuite.templates = function()
       return {
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
-          local l = retn(1, f:CreateLine(nil, nil, 'WowlessApiTemplateLine1,WowlessApiTemplateLine2'))
-          checkBoth(l)
+          local names = 'WowlessApiTemplateLine1,WowlessApiTemplateLine2'
+          if _G.__wowless then
+            checkBoth(retn(1, f:CreateLine(nil, nil, names)))
+          else
+            check1(false, (pcall(f.CreateLine, f, nil, nil, names)))
+          end
         end,
       }
     end,
@@ -81,51 +82,103 @@ G.testsuite.templates = function()
       return {
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
-          local m =
-            retn(1, f:CreateMaskTexture(nil, nil, 'WowlessApiTemplateMaskTexture1,WowlessApiTemplateMaskTexture2'))
-          checkBoth(m)
+          local names = 'WowlessApiTemplateMaskTexture1,WowlessApiTemplateMaskTexture2'
+          if _G.__wowless then
+            checkBoth(retn(1, f:CreateMaskTexture(nil, nil, names)))
+          else
+            check1(false, (pcall(f.CreateMaskTexture, f, nil, nil, names)))
+          end
         end,
       }
     end,
 
     -- Region/CreateAnimationGroup.lua ignores every argument beyond self
-    -- (it doesn't even accept a name), so the templateName the yaml
-    -- documents is not wired up at all yet -- comma-separated or not.
+    -- (it doesn't even accept a name), so templateName is never looked up
+    -- or applied -- not even a single valid name.
     CreateAnimationGroup = function()
       return {
-        ['comma-separated templates do not error'] = function()
-          local g = retn(1, CreateFrame('Frame'):CreateAnimationGroup('Bogus1,Bogus2'))
-          assertEquals('AnimationGroup', g:GetObjectType())
+        ['single template'] = function()
+          local f = CreateFrame('Frame')
+          local g = retn(1, f:CreateAnimationGroup('WowlessApiTemplateAnimationGroup1'))
+          if _G.__wowless then
+            check1(nil, g.apiTemplateFrom1)
+          else
+            check1(true, g.apiTemplateFrom1)
+          end
+        end,
+        ['comma-separated templates'] = function()
+          local f = CreateFrame('Frame')
+          local names = 'WowlessApiTemplateAnimationGroup1,WowlessApiTemplateAnimationGroup2'
+          if _G.__wowless then
+            local g = retn(1, f:CreateAnimationGroup(names))
+            check1(nil, g.apiTemplateFrom1)
+            check1(nil, g.apiTemplateFrom2)
+          else
+            check1(false, (pcall(f.CreateAnimationGroup, f, names)))
+          end
         end,
       }
     end,
 
     -- AnimationGroup/CreateAnimation.lua only reads its first argument
-    -- (animationType); name and templateName are accepted but discarded.
+    -- (animationType); name and templateName are accepted but discarded,
+    -- so not even a single valid template name is applied.
     CreateAnimation = function()
       return {
-        ['comma-separated templates do not error'] = function()
+        ['single template'] = function()
           local ag = CreateFrame('Frame'):CreateAnimationGroup()
-          local a = retn(1, ag:CreateAnimation('Animation', nil, 'Bogus1,Bogus2'))
-          assertEquals('Animation', a:GetObjectType())
+          local a = retn(1, ag:CreateAnimation('Animation', nil, 'WowlessApiTemplateAnimation1'))
+          if _G.__wowless then
+            check1(nil, a.apiTemplateFrom1)
+          else
+            check1(true, a.apiTemplateFrom1)
+          end
+        end,
+        ['comma-separated templates'] = function()
+          local ag = CreateFrame('Frame'):CreateAnimationGroup()
+          local names = 'WowlessApiTemplateAnimation1,WowlessApiTemplateAnimation2'
+          if _G.__wowless then
+            local a = retn(1, ag:CreateAnimation('Animation', nil, names))
+            check1(nil, a.apiTemplateFrom1)
+            check1(nil, a.apiTemplateFrom2)
+          else
+            check1(false, (pcall(ag.CreateAnimation, ag, 'Animation', nil, names)))
+          end
         end,
       }
     end,
 
-    -- Path/CreateControlPoint.lua reads name but discards templateName.
+    -- Path/CreateControlPoint.lua reads name but discards templateName,
+    -- so not even a single valid template name is applied (offsetx/offsety
+    -- stay at their 0 defaults instead of the template's values).
     CreateControlPoint = function()
       return {
-        ['comma-separated templates do not error'] = function()
+        ['single template'] = function()
           local path = retn(1, CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path'))
-          local point = retn(1, path:CreateControlPoint(nil, 'Bogus1,Bogus2'))
-          assertEquals('ControlPoint', point:GetObjectType())
+          local point = retn(1, path:CreateControlPoint(nil, 'WowlessApiTemplateControlPoint1'))
+          if _G.__wowless then
+            check2(0, 0, point:GetOffset())
+          else
+            check2(11, 0, point:GetOffset())
+          end
+        end,
+        ['comma-separated templates'] = function()
+          local path = retn(1, CreateFrame('Frame'):CreateAnimationGroup():CreateAnimation('Path'))
+          local names = 'WowlessApiTemplateControlPoint1,WowlessApiTemplateControlPoint2'
+          if _G.__wowless then
+            local point = retn(1, path:CreateControlPoint(nil, names))
+            check2(0, 0, point:GetOffset())
+          else
+            check1(false, (pcall(path.CreateControlPoint, path, nil, names)))
+          end
         end,
       }
     end,
 
     -- ModelScene/CreateActor.lua looks up its template argument as a
     -- single literal name (no splitting), so a comma-separated list is
-    -- just an unknown template name and errors.
+    -- just an unknown template name and errors. Confirmed against a real
+    -- client to work the same way.
     CreateActor = function()
       return {
         ['single template'] = function()

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -1061,6 +1061,7 @@
     </Scripts>
   </Frame>
 
+  <Include file='apitemplates.xml' />
   <Include file='generatedxml.xml' />
 
   <Script>

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1519,6 +1523,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1513,6 +1517,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1519,6 +1523,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1508,6 +1512,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1513,6 +1517,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1519,6 +1523,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1542,6 +1546,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -76,6 +76,8 @@ Animation:
       type: number
     enddelay:
       type: number
+    name:
+      type: string
     order:
       type: number
     parentkey:
@@ -89,6 +91,8 @@ Animation:
       type: number
     target:
       type: string
+    virtual:
+      type: boolean
   contents:
     tags:
       KeyValues:
@@ -1519,6 +1523,7 @@ Ui:
   contents:
     tags:
       Actor:
+      Animation:
       AnimationGroup:
       Font:
       FontFamily:


### PR DESCRIPTION
## Summary

Adds addon-side test coverage (`addon/Wowless/templates.lua` +
`addon/Wowless/apitemplates.xml`) for uiobject-creating APIs that accept a
`template`/`templateName` argument, to pin down whether each one currently
accepts a comma-separated list of multiple templates. Results confirmed
against both wowless and a real client:

- `CreateFrame` — splits on comma/space and applies every named template.
  Confirmed to work the same way on a real client. `CreateForbiddenFrame` is
  not addon-accessible (confirmed: calling it is `attempt to call a nil
  value` in-game), so it isn't tested separately; assume it behaves like
  `CreateFrame`.
- `Frame:CreateTexture`, `CreateFontString`, `CreateLine`, `CreateMaskTexture`
  — wowless splits these the same way as `CreateFrame` (via
  `CreateChildUIObject`), but **a real client treats the whole
  `templateName` string as one literal name**, so a comma-separated list
  just fails to match anything and errors (`Couldn't find inherited node`).
  Confirmed for all four, not just `CreateTexture`.
- `AnimatableObject:CreateAnimationGroup`, `AnimationGroup:CreateAnimation`
  — their wowless Lua implementations discard `name`/`templateName`
  entirely, so no template (single or multiple) is applied yet. A real
  client does perform a real template lookup here, so each is tested with
  real, individually-registered templates: a single valid name applies on
  a real client but not in wowless yet, and the comma-joined combination
  of two valid names is rejected on a real client the same way as the
  Texture-family methods above.
  - This also surfaced and fixed a real schema gap: `Animation` wasn't
    recognized as a top-level virtual template tag at all in wowless's
    `xml.yaml` (missing from `Ui`'s tag list, and missing `name`/`virtual`
    attribute support), even though it's a genuine top-level tag in the
    real client's `UI.xsd` (`Animation` → `AnimationRef` → `UiField`, the
    substitution group `<Ui>` accepts). Fixed across all products and
    verified end-to-end with a throwaway patch that actually threads
    `templateName` through `CreateAnimation`.
- `Path:CreateControlPoint` — intentionally left out of this PR.
  `ControlPoint` has no `virtual` attribute in the real `UI.xsd` at all and
  isn't a `UiField` substitution group member (it only exists inline
  inside `Path`'s `ControlPoints`), so it can't be a standalone template
  the same way the others are. What its `templateName` argument actually
  does is left for a separate follow-up investigation.
- `ModelScene:CreateActor` — looks up its `template` argument as one
  literal name (no splitting), so a comma-separated string is an unknown
  template and errors. Confirmed to work the same way on a real client.

This gives a repeatable way to compare wowless's template-list handling
against real-client behavior API by API, rather than relying on one-off
manual client testing.

## Test plan

- [x] `cmake --build --preset default --target test` passes across all
      products
- [x] Verified the new assertions are actually exercised by temporarily
      flipping expected values and confirming the harness fails (then
      reverted)
- [x] Verified the `Animation` schema fix end-to-end with a throwaway patch
      that threads `templateName` through `CreateAnimation` (reverted, not
      part of this PR)
- [x] Results cross-checked against multiple real-client runs of this test
      suite; test expectations and schema data updated to match confirmed
      behavior
- [x] `pre-commit run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpRjYqvcB4rfdGx9PD29Ee