### PR TITLE
xmleval: dedupe objname resolution in CreateUIObject

### DIFF
--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -53,14 +53,7 @@ return function(
   local initEarlyAttrs, initAttrs, initScriptBindings, initKids
 
   local function CreateUIObject(typename, objnamearg, parent, addonEnv, tmplsarg, id, layer, sublevel)
-    local objname
-    if type(objnamearg) == 'string' then
-      objname = ParentSub(objnamearg, parent)
-    elseif type(objnamearg) == 'number' then
-      objname = tostring(objnamearg)
-    end
     local objtype = uiobjecttypes.GetOrThrow(typename)
-    log(3, 'creating %s%s', objtype.name, objname and (' named ' .. objname) or '')
     local regid = nextid()
     local objp = new(regid, objtype.ctype)
     local obj = setmetatable({ [0] = objp }, objtype.sandboxMT)
@@ -68,7 +61,6 @@ return function(
     ud[1] = objp
     ud.luarep = obj
     ud.forbiddenrep = setmetatable({ [0] = objp }, objtype.sandboxMT)
-    ud.name = objname
     ud.type = typename
     userdata[regid] = ud
     setmetatable(ud, objtype.hostMT)
@@ -88,12 +80,16 @@ return function(
     if (layer or sublevel) and ud.SetDrawLayer then
       ud:SetDrawLayer(layer or ud.layer, sublevel or ud.sublevel)
     end
+    -- Resolved against the object's final parent, since an early `parent=`
+    -- attr (processed above) can reassign it before $parent substitution runs.
+    local objname
+    if type(objnamearg) == 'string' then
+      objname = ParentSub(objnamearg, ud.parent)
+    elseif type(objnamearg) == 'number' then
+      objname = tostring(objnamearg)
+    end
+    log(3, 'creating %s%s', objtype.name, objname and (' named ' .. objname) or '')
     if objname then
-      if type(objnamearg) == 'string' then
-        objname = ParentSub(objnamearg, ud.parent)
-      elseif type(objnamearg) == 'number' then
-        objname = tostring(objnamearg)
-      end
       ud.name = objname
       if genv[objname] then
         log(3, 'overwriting global ' .. objname)


### PR DESCRIPTION
## Summary
- `CreateUIObject` computed the object's name twice with identical string/number dispatch: once against the structural parent (used only to feed a debug log line), and again against the final parent after early attrs ran, since a `parent=` XML attr (an `early`-phase attr) can reassign `ud.parent` before `$parent` substitution should apply.
- Collapsed this to a single computation, done once early attrs have run, and moved the "creating ..." log line to fire where the name is actually resolved. No behavior change — the discarded intermediate `ud.name` write is gone, but nothing observed it.

## Test plan
- [x] `cmake --build --preset default --target test` — clean run, exit 0
- [x] `pre-commit run -a` — stylua, luacheck, build-and-test all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5gCBT4Vqs1VKRxFPKBCfE