### PR TITLE
ci: scope the vcpkg cache key by generator, not just OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,8 @@ jobs:
     - uses: actions/cache@v6
       with:
         path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-        key: vcpkg-${{ runner.os }}-${{ github.run_id }}
-        restore-keys: vcpkg-${{ runner.os }}
+        key: vcpkg-${{ runner.os }}-${{ matrix.config.generator }}-${{ github.run_id }}
+        restore-keys: vcpkg-${{ runner.os }}-${{ matrix.config.generator }}
     - uses: lukka/get-cmake@v4.4.0
     - run: cmake --preset default -G "${{ matrix.config.generator }}"
     - run: cmake --build --preset default --config Release --verbose


### PR DESCRIPTION
## Summary

- `windows-latest` (and also `ubuntu-latest`/`macos-latest`) run two
  generator variants each in the `build` matrix, but the vcpkg cache
  key/restore-keys were scoped only by `runner.os`. Since the primary key's
  uniquing suffix is `github.run_id` (always unique), every job always
  falls back to the shared `restore-keys` prefix -- so both generators on
  the same OS fight over one cache slot, and whichever generator's
  toolchain doesn't match the most recently saved entry gets a vcpkg
  binary cache full of artifacts for the wrong triplet, forcing a full
  from-source rebuild.
- Confirmed on PR #844's CI run: Ninja `windows-latest` configured in 25s
  (cache hit), Visual Studio `windows-latest` took ~11m40s in the same
  phase (cache miss) -- while both jobs' cache *restore* step itself
  completed in ~4s either way, so the slowness is vcpkg rebuilding after a
  restore that didn't actually help, not the restore itself being slow.
- Fix: include `matrix.config.generator` in both the key and restore-keys,
  so each OS+generator combination gets its own cache lineage.

## Test plan

- [x] `pre-commit run -a` passes (yaml validates, this repo's local build
      isn't affected since this is CI-only config)
- [ ] This PR's own CI run will still be a cache miss for every
      OS+generator combination (new key space), so it won't itself show a
      speedup -- the benefit shows up on the *next* run after this lands,
      once each lineage has something to restore. Worth a manual follow-up
      check on a subsequent PR/push to confirm windows-latest
      Visual-Studio configure time drops close to the Ninja windows-latest
      baseline (~25s-ish, plus whatever nprocs-native it needs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpRjYqvcB4rfdGx9PD29Ee