### PR TITLE
addon: add missing single-template coverage to CreateTexture/CreateFontString/CreateLine/CreateMaskTexture

### DIFF
--- a/addon/Wowless/apitemplates.xml
+++ b/addon/Wowless/apitemplates.xml
@@ -54,16 +54,20 @@
       <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
     </KeyValues>
   </Line>
-  <MaskTexture name='WowlessApiTemplateMaskTexture1' virtual='true'>
+  <!-- A MaskTexture-tagged virtual template isn't found by CreateMaskTexture
+       on a real client; a Texture-tagged one is (confirmed against a real
+       client), so these use Texture here even though the target is a
+       MaskTexture. -->
+  <Texture name='WowlessApiTemplateMaskTexture1' virtual='true'>
     <KeyValues>
       <KeyValue key='apiTemplateFrom1' value='true' type='boolean' />
     </KeyValues>
-  </MaskTexture>
-  <MaskTexture name='WowlessApiTemplateMaskTexture2' virtual='true'>
+  </Texture>
+  <Texture name='WowlessApiTemplateMaskTexture2' virtual='true'>
     <KeyValues>
       <KeyValue key='apiTemplateFrom2' value='true' type='boolean' />
     </KeyValues>
-  </MaskTexture>
+  </Texture>
 
   <AnimationGroup name='WowlessApiTemplateAnimationGroup1' virtual='true' looping='REPEAT' />
   <AnimationGroup name='WowlessApiTemplateAnimationGroup2' virtual='true' looping='BOUNCE' />

--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -37,6 +37,11 @@ G.testsuite.templates = function()
     -- match any template and errors.
     CreateTexture = function()
       return {
+        ['single template'] = function()
+          local f = CreateFrame('Frame')
+          local t = retn(1, f:CreateTexture(nil, nil, 'WowlessApiTemplateTexture1'))
+          check1(true, t.apiTemplateFrom1)
+        end,
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateTexture1,WowlessApiTemplateTexture2'
@@ -51,6 +56,11 @@ G.testsuite.templates = function()
 
     CreateFontString = function()
       return {
+        ['single template'] = function()
+          local f = CreateFrame('Frame')
+          local fs = retn(1, f:CreateFontString(nil, nil, 'WowlessApiTemplateFontString1'))
+          check1(true, fs.apiTemplateFrom1)
+        end,
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateFontString1,WowlessApiTemplateFontString2'
@@ -65,6 +75,11 @@ G.testsuite.templates = function()
 
     CreateLine = function()
       return {
+        ['single template'] = function()
+          local f = CreateFrame('Frame')
+          local l = retn(1, f:CreateLine(nil, nil, 'WowlessApiTemplateLine1'))
+          check1(true, l.apiTemplateFrom1)
+        end,
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateLine1,WowlessApiTemplateLine2'
@@ -79,6 +94,11 @@ G.testsuite.templates = function()
 
     CreateMaskTexture = function()
       return {
+        ['single template'] = function()
+          local f = CreateFrame('Frame')
+          local m = retn(1, f:CreateMaskTexture(nil, nil, 'WowlessApiTemplateMaskTexture1'))
+          check1(true, m.apiTemplateFrom1)
+        end,
         ['comma-separated templates'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateMaskTexture1,WowlessApiTemplateMaskTexture2'


### PR DESCRIPTION
## Summary

`addon/Wowless/templates.lua` (from PR #844) tests each Create*() API with
both a 'single template' and a 'comma-separated templates' sub-test, except
for `CreateTexture`/`CreateFontString`/`CreateLine`/`CreateMaskTexture`,
which only had the comma test. That's an oversight, not a deliberate
choice: those four were written early, focused narrowly on reproducing the
comma-list divergence you'd already found for CreateTexture, and never got
backfilled with the single-template baseline once that became the standard
pattern for the later Create*() tests in the same file.

Add `single template` for all four, mirroring `CreateFrame`'s
already-confirmed-working version: create with one valid, registered
template and assert its `KeyValue` marker landed.

`CreateMaskTexture`'s needed one more fix after real-client testing: a
`MaskTexture`-tagged virtual template isn't found by `CreateMaskTexture`
("Couldn't find inherited node"), even though the real `UI.xsd` gives
`MaskTexture` identical `name`/`virtual` attribute support to `Texture`
(both via the same `LayoutFrameAttributes` group, both
`substitutionGroup="LayoutFrameRef"`). Confirmed instead that a
`Texture`-tagged virtual template *is* found and applied by
`CreateMaskTexture` -- consistent with `MaskTexture` extending `Texture` --
so the template is declared that way, even though the object it's applied
to is a `MaskTexture`.

## Test plan

- [x] `cmake --build --preset default --target test` passes across all
      products
- [x] Verified the new assertions are actually exercised (temporarily
      flipped/broke expected values, confirmed the harness fails, then
      reverted)
- [x] Results cross-checked against a real client: `CreateTexture`,
      `CreateFontString`, `CreateLine` single-template cases passed as
      written; `CreateMaskTexture` needed the `Texture`-tagged-template fix
      above
- [x] `pre-commit run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpRjYqvcB4rfdGx9PD29Ee