### PR TITLE
api: CreateChildUIObject looks up templateName as a single literal name

### DIFF
--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -30,11 +30,10 @@ G.testsuite.templates = function()
     end,
 
     -- Frame:CreateTexture/CreateFontString/CreateLine/CreateMaskTexture all
-    -- go through api.CreateChildUIObject, which splits templateName the
-    -- same way CreateFrame does. Confirmed against a real client that this
-    -- is wrong for all four: the client treats the whole templateName
-    -- string as one literal name, so a comma-separated list just fails to
-    -- match any template and errors.
+    -- go through api.CreateChildUIObject, which looks templateName up as a
+    -- single literal name (no splitting), matching CreateActor's rule.
+    -- Confirmed against a real client: a comma-separated list is just an
+    -- unknown template name and errors.
     CreateTexture = function()
       return {
         ['single template'] = function()
@@ -42,14 +41,10 @@ G.testsuite.templates = function()
           local t = retn(1, f:CreateTexture(nil, nil, 'WowlessApiTemplateTexture1'))
           check1(true, t.apiTemplateFrom1)
         end,
-        ['comma-separated templates'] = function()
+        ['comma-separated templates error'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateTexture1,WowlessApiTemplateTexture2'
-          if _G.__wowless then
-            checkBoth(retn(1, f:CreateTexture(nil, nil, names)))
-          else
-            check1(false, (pcall(f.CreateTexture, f, nil, nil, names)))
-          end
+          check1(false, (pcall(f.CreateTexture, f, nil, nil, names)))
         end,
       }
     end,
@@ -61,14 +56,10 @@ G.testsuite.templates = function()
           local fs = retn(1, f:CreateFontString(nil, nil, 'WowlessApiTemplateFontString1'))
           check1(true, fs.apiTemplateFrom1)
         end,
-        ['comma-separated templates'] = function()
+        ['comma-separated templates error'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateFontString1,WowlessApiTemplateFontString2'
-          if _G.__wowless then
-            checkBoth(retn(1, f:CreateFontString(nil, nil, names)))
-          else
-            check1(false, (pcall(f.CreateFontString, f, nil, nil, names)))
-          end
+          check1(false, (pcall(f.CreateFontString, f, nil, nil, names)))
         end,
       }
     end,
@@ -80,14 +71,10 @@ G.testsuite.templates = function()
           local l = retn(1, f:CreateLine(nil, nil, 'WowlessApiTemplateLine1'))
           check1(true, l.apiTemplateFrom1)
         end,
-        ['comma-separated templates'] = function()
+        ['comma-separated templates error'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateLine1,WowlessApiTemplateLine2'
-          if _G.__wowless then
-            checkBoth(retn(1, f:CreateLine(nil, nil, names)))
-          else
-            check1(false, (pcall(f.CreateLine, f, nil, nil, names)))
-          end
+          check1(false, (pcall(f.CreateLine, f, nil, nil, names)))
         end,
       }
     end,
@@ -99,14 +86,10 @@ G.testsuite.templates = function()
           local m = retn(1, f:CreateMaskTexture(nil, nil, 'WowlessApiTemplateMaskTexture1'))
           check1(true, m.apiTemplateFrom1)
         end,
-        ['comma-separated templates'] = function()
+        ['comma-separated templates error'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateMaskTexture1,WowlessApiTemplateMaskTexture2'
-          if _G.__wowless then
-            checkBoth(retn(1, f:CreateMaskTexture(nil, nil, names)))
-          else
-            check1(false, (pcall(f.CreateMaskTexture, f, nil, nil, names)))
-          end
+          check1(false, (pcall(f.CreateMaskTexture, f, nil, nil, names)))
         end,
       }
     end,

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -25,10 +25,7 @@ return function(datalua, events, intrinsics, templates, uiobjects, uiobjecttypes
   end
 
   local function CreateChildUIObject(typename, self, name, inherits, layer, sublevel)
-    local tmpls = {}
-    for templateName in string.gmatch(inherits or '', '[^, ]+') do
-      table.insert(tmpls, templates.GetTemplateOrThrow(templateName))
-    end
+    local tmpls = inherits and { templates.GetTemplateOrThrow(inherits) }
     return xmleval.CreateUIObject(typename, name, self, nil, tmpls, nil, layer, sublevel)
   end
 


### PR DESCRIPTION
## Summary

Confirmed against a real client (PR #844/#847) that
`CreateTexture`/`CreateFontString`/`CreateLine`/`CreateMaskTexture` do not
split `templateName` on commas -- the whole string is looked up as one
literal template name, matching `ModelScene:CreateActor`'s existing
behavior. `api.CreateChildUIObject` (the shared implementation behind all
four) previously used the same comma/space-splitting `string.gmatch` loop
as `CreateFrame` -- which genuinely does support multiple templates and is
unaffected by this change -- so a comma-separated list silently applied
every named template instead of erroring like the real client does.

- `wowless/modules/api.lua`: `CreateChildUIObject` now does a single
  `templates.GetTemplateOrThrow(inherits)` lookup instead of splitting,
  mirroring `data/uiobjects/ModelScene/CreateActor.lua`'s existing pattern.
- `addon/Wowless/templates.lua`: the four affected tests drop their
  `_G.__wowless`-conditional structure and unconditionally assert the
  comma-separated case now errors, since wowless matches confirmed
  real-client behavior.

`CreateFrame` itself is untouched -- it has its own separate
comma/space-splitting logic in the same file, confirmed correct against a
real client, and isn't part of this change.

## Test plan

- [x] `cmake --build --preset default --target test` passes across all
      products (confirms no other code depended on the old splitting
      behavior for Texture/FontString/Line/MaskTexture)
- [x] Verified the updated assertions are actually exercised (temporarily
      flipped an expected value, confirmed the harness fails, then
      reverted)
- [x] `pre-commit run -a` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpRjYqvcB4rfdGx9PD29Ee