### PR TITLE
uiobjects: thread name/templateName through CreateAnimationGroup and CreateAnimation

### DIFF
--- a/addon/Wowless/templates.lua
+++ b/addon/Wowless/templates.lua
@@ -94,56 +94,36 @@ G.testsuite.templates = function()
       }
     end,
 
-    -- Region/CreateAnimationGroup.lua ignores every argument beyond self
-    -- (it doesn't even accept a name), so templateName is never looked up
-    -- or applied -- not even a single valid name.
+    -- Region/CreateAnimationGroup.lua looks templateName up as a single
+    -- literal name (no splitting), matching CreateActor's rule.
     CreateAnimationGroup = function()
       return {
         ['single template'] = function()
           local f = CreateFrame('Frame')
           local g = retn(1, f:CreateAnimationGroup(nil, 'WowlessApiTemplateAnimationGroup1'))
-          if _G.__wowless then
-            check1('NONE', (g:GetLooping()))
-          else
-            check1('REPEAT', (g:GetLooping()))
-          end
+          check1('REPEAT', (g:GetLooping()))
         end,
-        ['comma-separated templates'] = function()
+        ['comma-separated templates error'] = function()
           local f = CreateFrame('Frame')
           local names = 'WowlessApiTemplateAnimationGroup1,WowlessApiTemplateAnimationGroup2'
-          if _G.__wowless then
-            local g = retn(1, f:CreateAnimationGroup(nil, names))
-            check1('NONE', (g:GetLooping()))
-          else
-            check1(false, (pcall(f.CreateAnimationGroup, f, nil, names)))
-          end
+          check1(false, (pcall(f.CreateAnimationGroup, f, nil, names)))
         end,
       }
     end,
 
-    -- AnimationGroup/CreateAnimation.lua only reads its first argument
-    -- (animationType); name and templateName are accepted but discarded,
-    -- so not even a single valid template name is applied.
+    -- AnimationGroup/CreateAnimation.lua looks templateName up as a single
+    -- literal name (no splitting), matching CreateActor's rule.
     CreateAnimation = function()
       return {
         ['single template'] = function()
           local ag = CreateFrame('Frame'):CreateAnimationGroup()
           local a = retn(1, ag:CreateAnimation('Animation', nil, 'WowlessApiTemplateAnimation1'))
-          if _G.__wowless then
-            check1('NONE', (a:GetSmoothing()))
-          else
-            check1('IN', (a:GetSmoothing()))
-          end
+          check1('IN', (a:GetSmoothing()))
         end,
-        ['comma-separated templates'] = function()
+        ['comma-separated templates error'] = function()
           local ag = CreateFrame('Frame'):CreateAnimationGroup()
           local names = 'WowlessApiTemplateAnimation1,WowlessApiTemplateAnimation2'
-          if _G.__wowless then
-            local a = retn(1, ag:CreateAnimation('Animation', nil, names))
-            check1('NONE', (a:GetSmoothing()))
-          else
-            check1(false, (pcall(ag.CreateAnimation, ag, 'Animation', nil, names)))
-          end
+          check1(false, (pcall(ag.CreateAnimation, ag, 'Animation', nil, names)))
         end,
       }
     end,

--- a/data/uiobjects/AnimationGroup/CreateAnimation.lua
+++ b/data/uiobjects/AnimationGroup/CreateAnimation.lua
@@ -1,8 +1,8 @@
 local api, uiobjecttypes = ...
-return function(self, type)
+return function(self, type, name, templateName)
   local ltype = (type or 'animation'):lower()
   if not (uiobjecttypes.Has(ltype) and uiobjecttypes.InheritsFrom(ltype, 'animation')) then
     ltype = 'animation'
   end
-  return api.CreateUIObject(ltype, nil, self)
+  return api.CreateChildUIObject(ltype, self, name, templateName)
 end

--- a/data/uiobjects/Region/CreateAnimationGroup.lua
+++ b/data/uiobjects/Region/CreateAnimationGroup.lua
@@ -1,4 +1,4 @@
 local api = ...
-return function(self)
-  return api.CreateUIObject('animationgroup', nil, self)
+return function(self, name, templateName)
+  return api.CreateChildUIObject('animationgroup', self, name, templateName)
 end


### PR DESCRIPTION
## Summary

`Region/CreateAnimationGroup.lua` and `AnimationGroup/CreateAnimation.lua`
previously discarded every argument beyond `self` (and, for
`CreateAnimation`, the animation type), so `templateName` was never looked
up or applied. Confirmed against a real client that both do perform a real
template lookup: a single valid name applies correctly, and a comma-joined
pair of otherwise-valid names is rejected as an unknown template, matching
every other `Create*()` API in this family.

Delegate to `api.CreateChildUIObject`, which already does exactly this
lookup (single literal name, no splitting -- fixed in #848) -- the same
helper that already backs
`CreateTexture`/`CreateFontString`/`CreateLine`/`CreateMaskTexture`.

Updated `templates.lua` to drop the now-unnecessary
`_G.__wowless`-conditional structure for both `CreateAnimationGroup` and
`CreateAnimation`, since wowless matches confirmed real-client behavior
unconditionally now.

## Test plan

- [x] `cmake --build --preset default --target test` passes across all
      products (confirms nothing else relied on these two ignoring their
      arguments)
- [x] Verified the updated assertions are actually exercised (temporarily
      broke both expected values, confirmed the harness fails with the
      correct actual values, then reverted)
- [x] `pre-commit run -a` passes
- [ ] Not yet re-verified against a real client -- confident in this one
      since it reuses the exact `CreateChildUIObject` helper already
      confirmed correct for the Texture family in #848, but flagging since
      everything else in this template-testing effort has been
      client-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpRjYqvcB4rfdGx9PD29Ee