### PR TITLE
api,gencode,cgencode,mainloop: remove blast-radius-limiting re-exports

### DIFF
--- a/data/impl.yaml
+++ b/data/impl.yaml
@@ -257,7 +257,7 @@ coroutine.yield:
 CreateFont:
   impl:
     modules:
-      api:
+      xmleval:
 CreateForbiddenFrame:
   moduledelegate:
     name: api
@@ -289,7 +289,7 @@ difftime:
 EnumerateFrames:
   impl:
     modules:
-      api:
+      xmleval:
 error:
   stdlib: error
 fastrandom:

--- a/data/impl/CreateFont.lua
+++ b/data/impl/CreateFont.lua
@@ -1,9 +1,9 @@
-local api = ...
+local xmleval = ...
 local cache = {}
 return function(name)
   local font = cache[name]
   if not font then
-    font = api.CreateUIObject('font', name)
+    font = xmleval.CreateUIObject('font', name)
     cache[name] = font
   end
   return font

--- a/data/impl/EnumerateFrames.lua
+++ b/data/impl/EnumerateFrames.lua
@@ -1,5 +1,5 @@
-local api = ...
-local nextentry, arg = api.frames:entries()
+local xmleval = ...
+local nextentry, arg = xmleval.frames:entries()
 return function(frame)
   return nextentry(arg, frame)
 end

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -7,7 +7,6 @@ api:
     events:
     intrinsics:
     templates:
-    uiobjects:
     uiobjecttypes:
     xmleval:
 atlas:
@@ -20,12 +19,12 @@ calendar:
 cgencode:
   deps:
     addons:
-    api:
     events:
     log:
     luaobjects:
     uiobjects:
     units:
+    xmleval:
 clog:
   deps:
     datalua:
@@ -76,7 +75,8 @@ funtainer:
     security:
 gencode:
   deps:
-    api:
+    uiobjects:
+    xmleval:
 intrinsics:
   deps:
     log:
@@ -107,12 +107,12 @@ macrotext:
     security:
 mainloop:
   deps:
-    api:
     eventqueue:
     region:
     scripts:
     time:
     visibility:
+    xmleval:
 maxErrors:
   root:
     default: '0'

--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -32,7 +32,7 @@ Button/SetEnabled:
 Button/SetFontString:
   luafile:
     modules:
-      api:
+      uiobjects:
 Button/SetFormattedText:
   luafile:
 Button/SetHighlightAtlas:
@@ -133,18 +133,18 @@ MessageFrame/AddMessage:
 ModelScene/CreateActor:
   luafile:
     modules:
-      api:
       templates:
+      xmleval:
 MouseMixin/EnableMouse:
   luafile:
 MouseMixin/IsMouseEnabled:
   luafile:
 ParentedObject/GetDebugName:
   moduledelegate:
-    name: api
+    name: uiobjects
 ParentedObject/SetParent:
   moduledelegate:
-    name: api
+    name: uiobjects
 ParentedObjectBase/ClearParentKey:
   moduledelegate:
     name: parentkey
@@ -267,8 +267,8 @@ ScriptObject/SetScript:
 ScrollFrame/SetScrollChild:
   luafile:
     modules:
-      api:
       points:
+      uiobjects:
 Slider/Disable:
   luafile:
 Slider/Enable:

--- a/data/uiobjects/Button/SetFontString.lua
+++ b/data/uiobjects/Button/SetFontString.lua
@@ -1,5 +1,5 @@
-local api = ...
+local uiobjects = ...
 return function(self, value)
-  api.SetParent(value, self)
+  uiobjects.SetParent(value, self)
   self.fontstring = value
 end

--- a/data/uiobjects/ModelScene/CreateActor.lua
+++ b/data/uiobjects/ModelScene/CreateActor.lua
@@ -1,5 +1,5 @@
-local api, templates = ...
+local templates, xmleval = ...
 return function(self, name, template)
   local tmpls = template and { templates.GetTemplateOrThrow(template) }
-  return api.CreateUIObject('actor', name, self, nil, tmpls)
+  return xmleval.CreateUIObject('actor', name, self, nil, tmpls)
 end

--- a/data/uiobjects/ScrollFrame/SetScrollChild.lua
+++ b/data/uiobjects/ScrollFrame/SetScrollChild.lua
@@ -1,12 +1,12 @@
-local api, points = ...
+local points, uiobjects = ...
 return function(self, scrollChild)
   local old = self.scrollChild
   if old then
-    api.SetParent(old, nil)
+    uiobjects.SetParent(old, nil)
   end
   self.scrollChild = scrollChild
   if scrollChild then
-    api.SetParent(scrollChild, self)
+    uiobjects.SetParent(scrollChild, self)
     points.ClearAllPoints(scrollChild)
     points.SetPointInternal(scrollChild, 'TOPLEFT', self, 'TOPLEFT', 0, 0)
   end

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -1,4 +1,4 @@
-return function(datalua, events, intrinsics, templates, uiobjects, uiobjecttypes, xmleval)
+return function(datalua, events, intrinsics, templates, uiobjecttypes, xmleval)
   local GetIntrinsic = intrinsics.Get
   local HasType = uiobjecttypes.Has
   local InheritsFrom = uiobjecttypes.InheritsFrom
@@ -33,10 +33,5 @@ return function(datalua, events, intrinsics, templates, uiobjects, uiobjecttypes
     CreateChildUIObject = CreateChildUIObject,
     CreateForbiddenFrame = CreateFrame, -- TODO implement properly
     CreateFrame = CreateFrame,
-    CreateUIObject = xmleval.CreateUIObject,
-    frames = xmleval.frames,
-    GetDebugName = uiobjects.GetDebugName,
-    ParentSub = uiobjects.ParentSub,
-    SetParent = uiobjects.SetParent,
   }
 end

--- a/wowless/modules/cgencode.lua
+++ b/wowless/modules/cgencode.lua
@@ -1,12 +1,12 @@
 local bubblewrap = require('wowless.bubblewrap')
 
-return function(addons, api, events, log, luaobjects, uiobjects, units)
+return function(addons, events, log, luaobjects, uiobjects, units, xmleval)
   local function CreateLuaObject(typename)
     return luaobjects.CreateProxy(luaobjects.Create(typename))
   end
 
   local function CreateUiObject(typename)
-    return api.CreateUIObject(string.lower(typename)).luarep
+    return xmleval.CreateUIObject(string.lower(typename)).luarep
   end
 
   local function GetUiAddon(value)

--- a/wowless/modules/gencode.lua
+++ b/wowless/modules/gencode.lua
@@ -1,6 +1,6 @@
 local hlist = require('wowless.hlist')
 
-return function(api)
+return function(uiobjects, xmleval)
   local function ToTexture(parent, tex, obj)
     if type(tex) == 'string' or type(tex) == 'number' then
       local t = obj or parent:CreateTexture()
@@ -12,9 +12,9 @@ return function(api)
   end
 
   return {
-    CreateUIObject = api.CreateUIObject,
+    CreateUIObject = xmleval.CreateUIObject,
     hlist = hlist,
-    SetParent = api.SetParent,
+    SetParent = uiobjects.SetParent,
     ToTexture = ToTexture,
   }
 end

--- a/wowless/modules/mainloop.lua
+++ b/wowless/modules/mainloop.lua
@@ -1,7 +1,7 @@
-return function(api, eventqueue, region, scripts, time, visibility)
+return function(eventqueue, region, scripts, time, visibility, xmleval)
   local Advance = time.Advance
   local DrainEvents = eventqueue.DrainEvents
-  local frames = api.frames
+  local frames = xmleval.frames
   local GetRect = region.GetRect
   local IsVisible = visibility.IsVisible
   local RunScript = scripts.RunScript

--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -70,7 +70,7 @@ local function run(cfg)
     loglevel = cfg.loglevel or 0,
     maxErrors = cfg.maxErrors or math.huge,
   })
-  local api = modules.api
+  local xmleval = modules.xmleval
   local loader = modules.loader
   local system = modules.system
   local genv = modules.env.genv
@@ -137,7 +137,7 @@ local function run(cfg)
       local render = require('wowless.render')
       local screenWidth, screenHeight = system.GetScreenWidth(), system.GetScreenHeight()
       local function doit(name)
-        local data = render.frames2rects(api.frames, cfg.product, screenWidth, screenHeight)
+        local data = render.frames2rects(xmleval.frames, cfg.product, screenWidth, screenHeight)
         local fn = path.join(path.dirname(cfg.output), name .. '.yaml')
         require('pl.file').write(fn, require('wowapi.yaml').pprint(data))
       end
@@ -173,7 +173,7 @@ local function run(cfg)
         end
       end,
       clicks = function()
-        for frame in api.frames:entries() do
+        for frame in xmleval.frames:entries() do
           if frame:IsObjectType('button') and frame:IsVisible() then
             log(2, 'clicking %s', frame:GetDebugName())
             CallSafely(frame.Click, frame)
@@ -197,7 +197,7 @@ local function run(cfg)
         end
       end,
       enterleave = function()
-        for frame in api.frames:entries() do
+        for frame in xmleval.frames:entries() do
           if frame:IsVisible() then
             log(2, 'enter/leave %s', frame:GetDebugName())
             modules.scripts.RunScript(frame, 'OnEnter', true)


### PR DESCRIPTION
## Summary
- The xmleval refactor (264955dc8) left `api.lua` re-exporting `CreateUIObject`/`frames` (from `xmleval`) and `GetDebugName`/`ParentSub`/`SetParent` (from `uiobjects`), purely to keep every existing consumer referencing `api.X` unchanged while the module boundaries settled.
- Points every consumer at its real owning module directly instead: `gencode`, `cgencode`, `mainloop`, `runner.lua`, a handful of `data/impl`/`data/uiobjects` luafiles, and the `ParentedObject/GetDebugName` + `ParentedObject/SetParent` moduledelegates (these were the trickiest — they resolve `api.X` by module name declaratively in `data/uiobjectimpl.yaml`, not via a Lua-visible call site).
- `api.lua` now only exports its genuine surface: `CreateFrame`, `CreateForbiddenFrame`, `CreateChildUIObject`.
- No behavior change — pure internal wiring cleanup.

## Test plan
- [x] `cmake --build --preset default --target test` passes across all 8 products
- [x] pre-commit `build and test` hook passed on commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>