### PR TITLE
uiobjects: fold CreateActor onto the shared CreateChildUIObject helper

### DIFF
--- a/data/uiobjectimpl.yaml
+++ b/data/uiobjectimpl.yaml
@@ -133,8 +133,7 @@ MessageFrame/AddMessage:
 ModelScene/CreateActor:
   luafile:
     modules:
-      templates:
-      xmleval:
+      api:
 MouseMixin/EnableMouse:
   luafile:
 MouseMixin/IsMouseEnabled:

--- a/data/uiobjects/ModelScene/CreateActor.lua
+++ b/data/uiobjects/ModelScene/CreateActor.lua
@@ -1,5 +1,4 @@
-local templates, xmleval = ...
+local api = ...
 return function(self, name, template)
-  local tmpls = template and { templates.GetTemplateOrThrow(template) }
-  return xmleval.CreateUIObject('actor', name, self, nil, tmpls)
+  return api.CreateChildUIObject('actor', self, name, template)
 end


### PR DESCRIPTION
## Summary
- `ModelScene/CreateActor.lua` reimplemented the single-literal-name template lookup that `api.CreateChildUIObject` already provides (used by `CreateTexture`/`CreateFontString`/`CreateLine`/`CreateMaskTexture`/`CreateAnimationGroup`/`CreateAnimation`/`CreateControlPoint`). This was the last remaining duplication of that pattern, identified while auditing all `Create*()` uiobject APIs for template/templateName handling.
- Delegates to `api.CreateChildUIObject('actor', self, name, template)` instead, matching every other caller. No behavior change — same single-name lookup, same error on a comma-separated list.
- Drops the file's now-unnecessary direct `templates`/`xmleval` module dependencies in favor of just `api`.

## Test plan
- [x] `cmake --build --preset default --target test` passes across all 8 products
- [x] pre-commit `build and test` hook passed on commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>