### PR TITLE
xml,xmleval: emit real LUA_WARNING for unrecognized XML

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -184,6 +184,16 @@
       <OnLoad>end, error('this should not be executed')--</OnLoad>
     </Scripts>
   </WowlessIntrinsicType>
+  <Script>
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: WowlessIntrinsicType')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: Scripts')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: OnLoad')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 9) .. ' Unrecognized XML: WowlessIntrinsicType')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 10) .. ' Unrecognized XML attribute: name')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML attribute: intrinsic')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: Scripts')
+    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: OnLoad')
+  </Script>
   <Include file='evenmoreintrinsic.xml' />
   <Script>--[[ TODO requires more sophistication in api re intrinsics
     assertEquals(false, pcall(function() CreateFrame('WowlessEvenMoreIntrinsicType') end))

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -185,14 +185,14 @@
     </Scripts>
   </WowlessIntrinsicType>
   <Script>
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: WowlessIntrinsicType')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: Scripts')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: OnLoad')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 9) .. ' Unrecognized XML: WowlessIntrinsicType')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 10) .. ' Unrecognized XML attribute: name')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML attribute: intrinsic')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: Scripts')
-    table.insert(Wowless.ExpectedLuaWarnings, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: OnLoad')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: WowlessIntrinsicType')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: Scripts')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: OnLoad')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 9) .. ' Unrecognized XML: WowlessIntrinsicType')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 10) .. ' Unrecognized XML attribute: name')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML attribute: intrinsic')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: Scripts')
+    table.insert(Wowless.ExpectedNextFrame, 'Interface/AddOns/Wowless/test.xml:' .. (__LINE__ - 11) .. ' Unrecognized XML: OnLoad')
   </Script>
   <Include file='evenmoreintrinsic.xml' />
   <Script>--[[ TODO requires more sophistication in api re intrinsics

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -185,7 +185,7 @@ visibility:
 xml:
   deps:
     datalua:
-    events:
+    eventqueue:
 xmleval:
   deps:
     bindings:

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -185,6 +185,7 @@ visibility:
 xml:
   deps:
     datalua:
+    events:
 xmleval:
   deps:
     bindings:

--- a/spec/wowless/modules/xml_spec.lua
+++ b/spec/wowless/modules/xml_spec.lua
@@ -11,7 +11,7 @@ describe('xml', function()
   for _, p in ipairs(require('build.data.products')) do
     describe(p, function()
       local datalua = require('build.products.' .. p .. '.data')
-      local parse = xmlmodule(datalua, { SendEvent = function() end })
+      local parse = xmlmodule(datalua, { QueueEvent = function() end })
       -- ButtonText/NormalFont share a type (FontString/Font) with generic
       -- layered regions but belong to Button's own substitution group, not
       -- the generic one -- see issue #778.

--- a/spec/wowless/modules/xml_spec.lua
+++ b/spec/wowless/modules/xml_spec.lua
@@ -11,7 +11,7 @@ describe('xml', function()
   for _, p in ipairs(require('build.data.products')) do
     describe(p, function()
       local datalua = require('build.products.' .. p .. '.data')
-      local parse = xmlmodule(datalua)
+      local parse = xmlmodule(datalua, { SendEvent = function() end })
       -- ButtonText/NormalFont share a type (FontString/Font) with generic
       -- layered regions but belong to Button's own substitution group, not
       -- the generic one -- see issue #778.

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -81,21 +81,15 @@ return function(datalua, events)
     end,
   }
 
-  local function parseRoot(root, intrinsics, snapshot, filename, addonName, addonRoot)
+  local function parseRoot(root, intrinsics, snapshot, warningPath)
     local warnings = {}
-    -- issue #521: matches the "Interface/AddOns/<addon>/<relpath>" virtual
-    -- paths a real client reports in LUA_WARNING messages, regardless of
-    -- where wowless actually reads the file from disk.
-    local function warningPath()
-      return 'Interface/AddOns/' .. addonName .. '/' .. filename:sub(#addonRoot + 2)
-    end
     -- A real client keeps descending into an unrecognized element's
     -- children and attributes rather than dropping the whole subtree
     -- silently, flagging each one individually too.
     local function warnUnrecognized(e)
-      SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML: %s'):format(warningPath(), e._line, e._name))
+      SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML: %s'):format(warningPath, e._line, e._name))
       for _, k in ipairs(e._attr) do
-        SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML attribute: %s'):format(warningPath(), e._line, k))
+        SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML attribute: %s'):format(warningPath, e._line, k))
       end
       for _, kid in ipairs(e._children or {}) do
         if kid._type == 'ELEMENT' then
@@ -197,11 +191,11 @@ return function(datalua, events)
   end
 
   local intrinsics = {}
-  return function(xmlstr, filename, addonName, addonRoot)
+  return function(xmlstr, warningPath)
     local snapshot = {}
     for k, v in pairs(intrinsics) do
       snapshot[k] = v
     end
-    return parseRoot(xml2dom(xmlstr), intrinsics, snapshot, filename, addonName, addonRoot)
+    return parseRoot(xml2dom(xmlstr), intrinsics, snapshot, warningPath)
   end
 end

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -41,7 +41,8 @@ local function xml2dom(xmlstr)
   return stack[1]._children[1]
 end
 
-return function(datalua)
+return function(datalua, events)
+  local SendEvent = events.SendEvent
   local lang = datalua.xmlflat
   local stringenums = datalua.stringenums
   local enums = datalua.globals.Enum
@@ -80,15 +81,21 @@ return function(datalua)
     end,
   }
 
-  local function parseRoot(root, intrinsics, snapshot)
+  local function parseRoot(root, intrinsics, snapshot, filename, addonName, addonRoot)
     local warnings = {}
+    -- issue #521: matches the "Interface/AddOns/<addon>/<relpath>" virtual
+    -- paths a real client reports in LUA_WARNING messages, regardless of
+    -- where wowless actually reads the file from disk.
+    local function warningPath()
+      return 'Interface/AddOns/' .. addonName .. '/' .. filename:sub(#addonRoot + 2)
+    end
     -- A real client keeps descending into an unrecognized element's
     -- children and attributes rather than dropping the whole subtree
     -- silently, flagging each one individually too.
     local function warnUnrecognized(e)
-      table.insert(warnings, { kind = 'tag', line = e._line, name = e._name })
+      SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML: %s'):format(warningPath(), e._line, e._name))
       for _, k in ipairs(e._attr) do
-        table.insert(warnings, { kind = 'attr', line = e._line, name = k })
+        SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML attribute: %s'):format(warningPath(), e._line, k))
       end
       for _, kid in ipairs(e._children or {}) do
         if kid._type == 'ELEMENT' then
@@ -190,11 +197,11 @@ return function(datalua)
   end
 
   local intrinsics = {}
-  return function(xmlstr)
+  return function(xmlstr, filename, addonName, addonRoot)
     local snapshot = {}
     for k, v in pairs(intrinsics) do
       snapshot[k] = v
     end
-    return parseRoot(xml2dom(xmlstr), intrinsics, snapshot)
+    return parseRoot(xml2dom(xmlstr), intrinsics, snapshot, filename, addonName, addonRoot)
   end
 end

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -41,8 +41,8 @@ local function xml2dom(xmlstr)
   return stack[1]._children[1]
 end
 
-return function(datalua, events)
-  local SendEvent = events.SendEvent
+return function(datalua, eventqueue)
+  local QueueEvent = eventqueue.QueueEvent
   local lang = datalua.xmlflat
   local stringenums = datalua.stringenums
   local enums = datalua.globals.Enum
@@ -87,9 +87,9 @@ return function(datalua, events)
     -- children and attributes rather than dropping the whole subtree
     -- silently, flagging each one individually too.
     local function warnUnrecognized(e)
-      SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML: %s'):format(warningPath, e._line, e._name))
+      QueueEvent('LUA_WARNING', ('%s:%d Unrecognized XML: %s'):format(warningPath, e._line, e._name))
       for _, k in ipairs(e._attr) do
-        SendEvent('LUA_WARNING', ('%s:%d Unrecognized XML attribute: %s'):format(warningPath, e._line, k))
+        QueueEvent('LUA_WARNING', ('%s:%d Unrecognized XML attribute: %s'):format(warningPath, e._line, k))
       end
       for _, kid in ipairs(e._children or {}) do
         if kid._type == 'ELEMENT' then

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -82,6 +82,20 @@ return function(datalua)
 
   local function parseRoot(root, intrinsics, snapshot)
     local warnings = {}
+    -- A real client keeps descending into an unrecognized element's
+    -- children and attributes rather than dropping the whole subtree
+    -- silently, flagging each one individually too.
+    local function warnUnrecognized(e)
+      table.insert(warnings, { kind = 'tag', line = e._line, name = e._name })
+      for _, k in ipairs(e._attr) do
+        table.insert(warnings, { kind = 'attr', line = e._line, name = k })
+      end
+      for _, kid in ipairs(e._children or {}) do
+        if kid._type == 'ELEMENT' then
+          warnUnrecognized(kid)
+        end
+      end
+    end
     local function run(e, tn, tk)
       if e._type ~= 'ELEMENT' then
         error('invalid xml type ' .. e._type .. ' on child of ' .. tn)
@@ -89,7 +103,7 @@ return function(datalua)
       local tname = string.lower(e._name)
       local ty = lang[tname] or snapshot[tname]
       if not ty then
-        table.insert(warnings, 'unknown type ' .. tname)
+        warnUnrecognized(e)
         return nil
       end
       if ty.virtual then

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -800,17 +800,15 @@ return function(
     end
   end
 
-  -- issue #521: matches the "Interface/AddOns/<addon>/<relpath>" virtual
-  -- paths a real client reports in LUA_WARNING messages for XML-sourced
-  -- issues, regardless of where wowless actually reads the file from disk.
-  local function warningPath(ctx)
-    return 'Interface/AddOns/' .. ctx.addonName .. '/' .. ctx.filename:sub(#ctx.addonRoot + 2)
-  end
-
   local function loadXml(addonName, addonEnv, addonRoot, useSecureEnv, filename, xmlstr)
     local dir = path.dirname(filename)
     security.CallSafely(function()
-      local root, warnings = parseXml(xmlstr)
+      local root, warnings = parseXml(xmlstr, filename, addonName, addonRoot)
+      if loglevel >= 3 then
+        for _, warning in ipairs(warnings) do
+          log(3, filename .. ': ' .. warning)
+        end
+      end
       local ctx = {
         addonEnv = addonEnv,
         addonName = addonName,
@@ -822,15 +820,6 @@ return function(
         useAddonEnv = false,
         useSecureEnv = useSecureEnv,
       }
-      for _, warning in ipairs(warnings) do
-        if type(warning) == 'table' then
-          local msg = warning.kind == 'tag' and 'Unrecognized XML: ' .. warning.name
-            or 'Unrecognized XML attribute: ' .. warning.name
-          SendEvent('LUA_WARNING', ('%s:%d %s'):format(warningPath(ctx), warning.line, msg))
-        elseif loglevel >= 3 then
-          log(3, filename .. ': ' .. warning)
-        end
-      end
       loadElement(ctx, root)
     end)
   end

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -800,15 +800,17 @@ return function(
     end
   end
 
+  -- issue #521: matches the "Interface/AddOns/<addon>/<relpath>" virtual
+  -- paths a real client reports in LUA_WARNING messages for XML-sourced
+  -- issues, regardless of where wowless actually reads the file from disk.
+  local function warningPath(ctx)
+    return 'Interface/AddOns/' .. ctx.addonName .. '/' .. ctx.filename:sub(#ctx.addonRoot + 2)
+  end
+
   local function loadXml(addonName, addonEnv, addonRoot, useSecureEnv, filename, xmlstr)
     local dir = path.dirname(filename)
     security.CallSafely(function()
       local root, warnings = parseXml(xmlstr)
-      if loglevel >= 3 then
-        for _, warning in ipairs(warnings) do
-          log(3, filename .. ': ' .. warning)
-        end
-      end
       local ctx = {
         addonEnv = addonEnv,
         addonName = addonName,
@@ -820,6 +822,15 @@ return function(
         useAddonEnv = false,
         useSecureEnv = useSecureEnv,
       }
+      for _, warning in ipairs(warnings) do
+        if type(warning) == 'table' then
+          local msg = warning.kind == 'tag' and 'Unrecognized XML: ' .. warning.name
+            or 'Unrecognized XML attribute: ' .. warning.name
+          SendEvent('LUA_WARNING', ('%s:%d %s'):format(warningPath(ctx), warning.line, msg))
+        elseif loglevel >= 3 then
+          log(3, filename .. ': ' .. warning)
+        end
+      end
       loadElement(ctx, root)
     end)
   end

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -803,12 +803,6 @@ return function(
   local function loadXml(addonName, addonEnv, addonRoot, useSecureEnv, filename, xmlstr)
     local dir = path.dirname(filename)
     security.CallSafely(function()
-      local root, warnings = parseXml(xmlstr, filename, addonName, addonRoot)
-      if loglevel >= 3 then
-        for _, warning in ipairs(warnings) do
-          log(3, filename .. ': ' .. warning)
-        end
-      end
       local ctx = {
         addonEnv = addonEnv,
         addonName = addonName,
@@ -820,6 +814,12 @@ return function(
         useAddonEnv = false,
         useSecureEnv = useSecureEnv,
       }
+      local root, warnings = parseXml(xmlstr, warningPath(ctx))
+      if loglevel >= 3 then
+        for _, warning in ipairs(warnings) do
+          log(3, filename .. ': ' .. warning)
+        end
+      end
       loadElement(ctx, root)
     end)
   end


### PR DESCRIPTION
Elements/attributes wowless doesn't recognize previously only hit a
debug log, never the LUA_WARNING event a real client fires. xml.lua's
run() now recurses into an unrecognized element's children and
attributes instead of dropping the whole subtree after one warning,
matching the real client's behavior of flagging each descendant
individually. xmleval.lua's loadXml formats those into
Interface/AddOns/<addon>/<file>:<line> Unrecognized XML[ attribute]:
<name> and sends them as real LUA_WARNING events, via xml.lua calling
SendEvent directly (given the pre-normalized warning path) rather than
threading structured data back through the warnings return value.

test.xml's WowlessIntrinsicType negative-test block (a real client
correctly treats a same-file forward-referenced intrinsic as
unrecognized, since each XML file's parser is locked in on creation)
now registers the 8 matching expected warnings via a __LINE__-offset
Script, same technique as #855. The disabled pcall/CreateFrame
assertion a few lines below is unrelated test debt and is left
untouched; GetErrorCount() behavior is unaffected.

Addresses #856, a blocker for #521.

Supersedes #857, which GitHub auto-closed when its base branch
(#855's branch) was deleted on merge — same branch, rebased onto the
now-merged main.

## Test plan

- [x] `cmake --build --preset default --target test` (exit 0, no output,
      across all 8 products)
- [x] `stylua --check` / `luacheck` on the changed Lua files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VZTt4DL54ijyvvAjQ7ydR
