### PR TITLE
runner: synthesize WorldFrame under implicitgodframes, like UIParent

### DIFF
--- a/wowless/runner.lua
+++ b/wowless/runner.lua
@@ -103,6 +103,12 @@ local function run(cfg)
   if runnercfg.implicitgodframes then
     local uiparent = modules.api.CreateFrame('Frame', 'UIParent')
     modules.points.SetAllPointsInternal(uiparent)
+    local worldframe = modules.api.CreateFrame('Frame', 'WorldFrame')
+    -- WORLD is a real frameStrata value, but only WorldFrame has it,
+    -- confirmed against a real client; matches the XML-tag path in
+    -- xmleval.lua's loadElement.
+    worldframe.frameStrata = 'WORLD'
+    modules.points.SetAllPointsInternal(worldframe)
   end
   return withglobaltable(genv, function()
     loader.loadAddons()


### PR DESCRIPTION
Products without the real FrameXML that would otherwise create
WorldFrame (currently just wowt, via config.runner.implicitgodframes)
never got one, surfacing as "Couldn't find relative frame: WorldFrame"
(Blizzard_FrameXML/Mainline/ZoneText.xml:62) once anchor-resolution
LUA_WARNINGs went real (#855, #521). Synthesize it the same way
UIParent already is, including the WORLD frameStrata xmleval.lua's
XML-tag path already gives it.

Found by running the outs target after #855/#858 merged and observing
that no product's output was empty anymore -- of the four issues that
surfaced, this was the simplest since UIParent already established the
pattern.

## Test plan

- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] Re-ran `products/wowt/log.txt` (the outs target's per-product
      output): the WorldFrame warning is gone (239 -> 234 lines, exactly
      the one entry's worth), the three unrecognized-XML issues
      (ForbiddenAspect, ColorAlphaTexture, ArchaeologyDigSiteFrame,
      tracked separately) are unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VZTt4DL54ijyvvAjQ7ydR
