### PR TITLE
data: add ColorAlphaTexture/ColorAlphaThumbTexture XML tags

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -281,9 +281,27 @@ Color:
       type: number
     r:
       type: number
+ColorAlphaTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaTexture
+      parenttype: ColorSelect
+  sealed: true
+ColorAlphaThumbTexture:
+  extends: Texture
+  impl:
+    call:
+      argument: self
+      parentmethod: SetColorAlphaThumbTexture
+      parenttype: ColorSelect
+  sealed: true
 ColorSelect:
   contents:
     tags:
+      ColorAlphaTexture:
+      ColorAlphaThumbTexture:
       ColorValueTexture:
       ColorValueThumbTexture:
       ColorWheelTexture:


### PR DESCRIPTION
ColorSelect's XML schema already recognized ColorWheelTexture/
ColorWheelThumbTexture and ColorValueTexture/ColorValueThumbTexture --
the analogous ColorAlphaTexture/ColorAlphaThumbTexture pair (the alpha
slider in ColorPickerFrame.xml) was simply missing, despite the
underlying SetColorAlphaTexture/SetColorAlphaThumbTexture uiobject
methods already existing with matching signatures. Pure data gap, same
pattern across all 8 products.

Found via the outs target after #855/#858 went real: ColorPickerFrame.xml
cascaded into ~20 "Unrecognized XML" warnings per affected product.

## Test plan

- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] Re-ran the outs target for wow, wowxptr, wowt: wow and wowxptr's
      output is now completely empty. wowt drops from 46 warning
      entries to 24, removing exactly the ColorAlphaTexture/
      ColorAlphaThumbTexture cascade and leaving only the unrelated
      ForbiddenAspect issue (tracked separately).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VZTt4DL54ijyvvAjQ7ydR
