### PR TITLE
data,xmleval,gentest: recognize ForbiddenAspects/ForbiddenAspect

### DIFF
--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -542,6 +542,16 @@ FontStringHeader2:
 FontStringHeader3:
   extends: FontString
   sealed: true
+ForbiddenAspect:
+  attributes:
+    aspect:
+      required: true
+      type:
+        enum: ForbiddenAspect
+ForbiddenAspects:
+  contents:
+    tags:
+      ForbiddenAspect:
 Frame:
   attributes:
     clampedtoscreen:
@@ -619,6 +629,7 @@ Frame:
     tags:
       Animations:
       Attributes:
+      ForbiddenAspects:
       Frames:
       HitRectInsets:
       Layers:

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -250,14 +250,13 @@ local function templateElement(uiobjectApis, chain, attrKey, key, value)
 end
 
 -- Every (tag, attribute) pair typed stringenum:/enum:, for tags reachable
--- from Frame (see frameChains) -- these are eligible for per-product
--- XML-attribute-value template tests. An eligible attribute's impl is
--- required to be field-based (data/schemas/xml.yaml's attribute impl
--- taggedunion also allows method/internal/loadfile/scope, but every
--- stringenum-/enum-typed attribute reachable from Frame today uses
--- `impl.field` directly) -- resolve the field's default and real getter
--- method via computeUiobjectApis's already-computed, inherits-flattened
--- field/getter data, rather than re-deriving either from string transforms.
+-- from Frame (see frameChains), whose impl is field-based
+-- (data/schemas/xml.yaml's attribute impl taggedunion also allows
+-- method/internal/loadfile/scope, or no impl at all) -- these are
+-- eligible for per-product XML-attribute-value template tests. Resolve
+-- the field's default and real getter method via computeUiobjectApis's
+-- already-computed, inherits-flattened field/getter data, rather than
+-- re-deriving either from string transforms.
 --
 -- frameChains doesn't guarantee every tag has one unambiguous chain (see
 -- its comment, and issue #781) -- only assert that here, lazily, for a
@@ -271,8 +270,8 @@ local function discoverCases(p)
     if chains[tag] then
       for attrKey, attrDef in pairs(tdef.attributes or {}) do
         local ty = attrDef.type
-        if ty.stringenum or ty.enum then
-          local fieldName = assert(attrDef.impl.field, 'unsupported attribute impl for ' .. tag .. '.' .. attrKey)
+        local fieldName = (ty.stringenum or ty.enum) and attrDef.impl and attrDef.impl.field
+        if fieldName then
           local fv = uiobjectApis[tag].fields[fieldName]
           local chain = chains[tag]
           for _, t in ipairs(chain) do

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -401,6 +401,9 @@ return function(
       local name, _, flags = parent:GetFont()
       parent:SetFont(name, e.kids[#e.kids].attr.val, flags)
     end,
+    -- TODO wire up AddForbiddenAspects once something depends on it; for
+    -- now this just keeps the tag from being flagged as unrecognized.
+    forbiddenaspects = function() end,
     gradient = function(_, e, parent)
       local minColor, maxColor
       for _, kid in ipairs(e.kids) do


### PR DESCRIPTION
wowt-only: ForbiddenAspectTemplates.xml and two other real FrameXML
files use these as plain XML tags, cascading into ~20 "Unrecognized
XML" warnings once that check went real (#856, #858). No impl for
either yet -- AddForbiddenAspects (already a real UIObject method) is
just not wired up, since nothing depends on the actual behavior. Just
makes the tags structurally recognized: ForbiddenAspects is a plain
wrapper (no impl at all, matching KeyValue-style leaves), and gets a
no-op entry in xmleval.lua's xmllang so the runtime dispatch doesn't
hit "unimplemented xml tag".

That exposed a real bug in gentest.lua's discoverCases: it asserted
every enum/stringenum-typed attribute reachable from Frame has
impl.field set, to auto-generate a per-value template test. aspect
(ForbiddenAspect's own attribute) doesn't, since it isn't a simple
gettable/settable field -- the assumption itself was wrong, not just
inapplicable here. discoverCases now treats attributes without
impl.field as ineligible for that coverage instead of crashing.

## Test plan

- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] Re-ran the outs target for wowt: output is now completely empty
      (all of #859/#860/this combined resolve every wowt issue from
      the original outs survey; only the classic-family
      ArchaeologyDigSiteFrame issue remains, tracked separately)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VZTt4DL54ijyvvAjQ7ydR
