### PR TITLE
xml,test: emit and expect the AnimationGroup.looping nonsense LUA_WARNING

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -1,4 +1,22 @@
 <Ui>
+  <!--
+    A real client warns on this one gentest.lua-generated nonsense negative
+    case (AnimationGroup.looping) in WowlessData's templates.xml. Hardcoded
+    because gentest.lua doesn't thread expected-warning data through
+    templates.lua yet; see issue #864 for the general fix. The line number
+    differs only for wow_classic_era. WowlessData's XML is structurally
+    parsed (and this warning queued) before any of this addon's own, so
+    this must be registered first.
+  -->
+  <Script>
+    table.insert(
+      Wowless.ExpectedNextFrame,
+      'Interface/AddOns/WowlessData/templates.xml:'
+        .. (_G.WowlessData.product == 'wow_classic_era' and 162 or 177)
+        .. ' AnimationGroup AnimationGroup: Invalid looping value: nonsense'
+    )
+  </Script>
+
   <Script>
     WowlessXmlErrors = {}
     WowlessOldErrorHandler = geterrorhandler()

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -81,6 +81,11 @@ return function(datalua, eventqueue)
     end,
   }
 
+  -- Confirmed against a real client; see issue #864 for the general fix.
+  local warnsOnInvalidValue = {
+    animationgroup = { looping = true },
+  }
+
   local function parseRoot(root, intrinsics, snapshot, warningPath)
     local warnings = {}
     -- A real client keeps descending into an unrecognized element's
@@ -128,6 +133,12 @@ return function(datalua, eventqueue)
           local v = e._attr[k]
           local vv = dispatch(attributeTypes, attr, v)
           if vv == nil then
+            if (warnsOnInvalidValue[tname] or {})[an] then
+              QueueEvent(
+                'LUA_WARNING',
+                ('%s:%d %s %s: Invalid %s value: %s'):format(warningPath, e._line, e._name, e._name, k, v)
+              )
+            end
             table.insert(warnings, 'attribute ' .. k .. ' has invalid value ' .. v)
           else
             resultAttrs[an] = vv


### PR DESCRIPTION
## Summary
- Confirmed against a real client that an invalid `AnimationGroup.looping`
  value emits a `LUA_WARNING`. `wowless/modules/xml.lua` now queues that
  warning for this one narrowly-allowlisted case instead of only
  debug-logging it.
- `addon/Wowless/test.xml` registers the corresponding expected string
  (hardcoded, since `gentest.lua` doesn't thread expected-warning data
  through `templates.lua`'s generated negative-value candidates yet).
  This is the interim fix; #864 tracks the general fix.

## Test plan
- [x] `cmake --build --preset default --target test` passes clean (exit 0,
      no output) across all 8 products.