### PR TITLE
xmleval,generatexmltest: only prefix "Frame " on Unknown script element for non-Frame types

### DIFF
--- a/data/products/wowt/config.yaml
+++ b/data/products/wowt/config.yaml
@@ -108,6 +108,7 @@ runner:
     PTRFEEDBACK:
     USERANDOM:
 runtime:
+  bareScriptWarning: true
   discord: true
   enummetafix: true
   send_isfromitem: true

--- a/data/schemas/config.yaml
+++ b/data/schemas/config.yaml
@@ -78,6 +78,8 @@ type:
     runtime:
       type:
         record:
+          bareScriptWarning:
+            type: flag
           discord:
             type: flag
           enummetafix:

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -81,7 +81,8 @@ local content = {
           if v then
             table.insert(expected, k)
           elseif _G.WowlessData.ScriptTypes[k] then
-            local fmt = 'Frame ModelSceneActor: Unknown script element %%s'
+            local prefix = _G.WowlessData.Config.runtime.bareScriptWarning and '' or 'Frame '
+            local fmt = prefix .. 'ModelSceneActor: Unknown script element %%s'
             table.insert(_G.Wowless.ExpectedLuaWarnings, fmt:format(k))
           else
             table.insert(_G.Wowless.ExpectedNextFrame, 'Unrecognized XML: ' .. k)

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -248,7 +248,8 @@ return function(
 
   local function bindScript(script, obj, env, intrinsic)
     if not scripts.HasScript(obj, script.type) then
-      local fmt = 'Frame %s: Unknown script element %s'
+      local prefix = datalua.config.runtime.bareScriptWarning and '' or 'Frame '
+      local fmt = prefix .. '%s: Unknown script element %s'
       SendEvent('LUA_WARNING', fmt:format(uiobjecttypes.GetObjectType(obj), script.name))
       return
     end


### PR DESCRIPTION
## Summary
- The `Unknown script element` `LUA_WARNING` unconditionally prepended `Frame ` to the object type name. A wowt (12.1.x PTR) log capture showed ModelSceneActor's warning without that prefix, but every other product still has it.
- This isn't tied to ModelSceneActor specifically: its `Actor` type inherits the same non-Frame bases (`ParentedObjectBase`/`RegionBase`/`ScriptObjectBase`) identically across every product, so a per-uiobject bit can't explain a wowt-only difference — it's a client-wide behavior change on that build.
- Adds a `bareScriptWarning` flag to `config.yaml`'s `runtime` record (alongside the existing product-wide runtime bits like `discord`/`enummetafix`), set `true` only for `wowt`. `xmleval.lua`'s `bindScript` reads it directly off `datalua.config.runtime` (already available in that module). `generatexmltest.lua`'s generated Actor script-warning test reads the matching `_G.WowlessData.Config.runtime` at addon runtime — `Config` already exposes the full per-product `config.yaml`, so no new plumbing was needed there.
- Out of scope: the separate `Unknown frame type: VectorGraphics` warning noted in the same capture.

## Test plan
- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] `pre-commit run` on the changed files (all hooks pass, including `build and test`, `schema_coverage_spec`)
- [x] Verified `build/products/wowt/WowlessData/config.lua` has `bareScriptWarning = true` under `runtime` while `build/products/wow/WowlessData/config.lua` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYwMJu2y2wR6ywS3VqL8a7