### PR TITLE
config: warn on CreateFrame('VectorGraphics') on wowt

### DIFF
--- a/data/products/wowt/config.yaml
+++ b/data/products/wowt/config.yaml
@@ -116,4 +116,5 @@ runtime:
     fontstring:
     line:
     texture:
+    vectorgraphics:
     worldframe:


### PR DESCRIPTION
## Summary
- Follow-up to #868's ModelSceneActor fix, for the other diff noted in the same wowt log capture: `Unknown frame type: VectorGraphics`.
- `VectorGraphics` is a new type that only exists in wowt's (12.1.x) uiobjects.yaml, inheriting `LayeredRegion`/`ScriptObject` -- not `Frame` -- the same shape as `Texture`/`FontString`/`Line`, which already trigger `api.lua`'s "Unknown frame type" `LUA_WARNING` path via `runtime.warners` when passed to `CreateFrame`. `vectorgraphics` was just missing from that set.
- Data-only change; adds `vectorgraphics:` to wowt's `runtime.warners`, matching the existing alphabetical entries.

## Test plan
- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] `pre-commit run` on the changed file (all hooks pass, including `build and test`)
- [x] Verified `build/products/wowt/WowlessData/config.lua` now has `vectorgraphics` in `runtime.warners`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYwMJu2y2wR6ywS3VqL8a7