### PR TITLE
test: probe VectorGraphics as a Layer child XML tag

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -215,6 +215,21 @@
     table.insert(_G.Wowless.ExpectedLuaWarnings, 'WowlessEvenMoreIntrinsicType')]]--
   </Script>
 
+  <!-- VectorGraphics has a uiobjects.yaml entry (wowt only) but no XML tag
+       definition on any product; this documents today's actual behavior
+       (unrecognized XML) as a real-client probe for whether it belongs in
+       Layer's tag list like Texture/FontString/Line. -->
+  <Frame>
+    <Layers>
+      <Layer>
+        <VectorGraphics />
+      </Layer>
+    </Layers>
+  </Frame>
+  <Script>
+    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: VectorGraphics')
+  </Script>
+
   <!-- https://github.com/wowless/wowless/issues/714: a method= script bound in a
        base virtual template should see a KeyValue override applied by a more-derived
        template later in the same inherits= chain, not the value captured when the


### PR DESCRIPTION
## Summary
- Follow-up to #868/#869 (ModelSceneActor's script-warning prefix and the `CreateFrame('VectorGraphics')` warner), digging into a lead from that investigation: `VectorGraphics` inherits `LayeredRegion` -- the same base as `Texture`/`FontString`/`Line`, the exact three tags `Layer.contents.tags` allows -- but it has no XML tag definition on any product's `xml.yaml` at all today, only a Lua-creatable `uiobjects.yaml` entry (wowt only).
- I don't have access to a real UI.xsd extract in this environment (`tools/fetch.lua` needs live CDN/CASC access), so I can't confirm the real tag name/attributes/containment directly. Rather than guessing at `xml.yaml` schema data, this adds a `<VectorGraphics />` inside a `<Layer>` in `addon/Wowless/test.xml` and asserts today's actual (and correct) behavior: it's unrecognized XML, same as any other undefined tag.
- This is a probe, not a schema change: the next time this test suite runs against the real wowt client and gets diffed (the same mechanism that surfaced the ModelSceneActor and `CreateFrame('VectorGraphics')` issues), a real client that already accepts `<VectorGraphics>` as a `Layer` child would show up as a diff here, giving us the confirmation needed to build out real `xml.yaml` support with confidence.

## Test plan
- [x] `cmake --build --preset default --target test` (exit 0, no output, across all products)
- [x] `pre-commit run` on the changed file (all hooks pass, including `build and test`)
- [x] Confirmed the generated `build/addon/Wowless/test.xml` contains the new case and expects `Unrecognized XML: VectorGraphics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYwMJu2y2wR6ywS3VqL8a7