### PR TITLE
api: fail CreateFrame on an intrinsic of an intrinsic

### DIFF
--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -210,9 +210,9 @@
     table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: OnLoad')
   </Script>
   <Include file='evenmoreintrinsic.xml' />
-  <Script>--[[ TODO requires more sophistication in api re intrinsics
+  <Script>
     assertEquals(false, pcall(function() CreateFrame('WowlessEvenMoreIntrinsicType') end))
-    table.insert(_G.Wowless.ExpectedLuaWarnings, 'WowlessEvenMoreIntrinsicType')]]--
+    table.insert(_G.Wowless.ExpectedLuaWarnings, 'Unknown frame type: WowlessEvenMoreIntrinsicType')
   </Script>
 
   <!-- https://github.com/wowless/wowless/issues/714: a method= script bound in a

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -8,8 +8,11 @@ return function(datalua, events, intrinsics, templates, uiobjecttypes, xmleval)
     local ltype = string.lower(type)
     local intrinsicEntry = GetIntrinsic(ltype)
     local basetype = intrinsicEntry and intrinsicEntry.basetype or ltype
-    if not HasType(basetype) or not InheritsFrom(basetype, 'frame') then
-      if datalua.config.runtime.warners[ltype] then
+    -- issue #116: an intrinsic of an intrinsic parses fine but a real client
+    -- refuses to instantiate it, the same way it does an unknown frame type.
+    local nested = intrinsicEntry and intrinsicEntry.nested
+    if nested or not HasType(basetype) or not InheritsFrom(basetype, 'frame') then
+      if nested or datalua.config.runtime.warners[ltype] then
         SendEvent('LUA_WARNING', 'Unknown frame type: ' .. type)
       end
       error('CreateFrame: Unknown frame type \'' .. type .. '\'', 0)


### PR DESCRIPTION
## Summary
- Closes #116: the remaining `CreateFrame` half of the fix. PR #871 already made XML-tag instantiation of an intrinsic of an intrinsic refuse cleanly with an `Unknown frame type` warning; this does the same for `CreateFrame`, which a real client also rejects for this scenario.
- `intrinsics.Get` already tags an intrinsic as `nested` when its declaring tag was itself another intrinsic (from #871). `CreateFrame` now treats `nested` as an unconditional failure, folded into the existing `HasType`/`InheritsFrom` check and reusing the exact same `SendEvent('LUA_WARNING', 'Unknown frame type: ' .. type)` + `error(...)` path the curated `warners` config already uses for other unknown-type strings — no new message format.
- Uncommented the previously-disabled test in `addon/Wowless/test.xml` (`TODO requires more sophistication in api re intrinsics`) and corrected its expected warning text to the full message.

## Test plan
- [x] `cmake --build --preset default --target test` passes for all 8 products (also re-run by the `build and test` pre-commit hook on this commit)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>