### PR TITLE
xml,xmleval,gentest,data: warn Unknown frame type for unknowntype XML tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,7 @@ foreach(product ${products})
   gentest(templates.lua templates)
   gentest(templates.xml templatexml)
   gentest(uiobjectapis.lua uiobjectapis)
+  gentest(xml.lua xml)
   add_custom_command(
     OUTPUT ${product}_addon.txt
     COMMAND ${CMAKE_COMMAND} -E touch ${product}_addon.txt
@@ -1054,6 +1055,7 @@ set(testaddon_outs)
 foreach(
   f
   apitemplates.xml
+  archaeologydigsiteframe.xml
   arraydiff.lua
   asynctests.lua
   evenmoreintrinsic.xml

--- a/addon/Wowless/Wowless.toc
+++ b/addon/Wowless/Wowless.toc
@@ -13,6 +13,7 @@ arraydiff.lua
 funtainer.lua
 luaobjects.lua
 test.xml
+archaeologydigsiteframe.xml
 generated.lua
 uiobjects.lua
 templates.lua

--- a/addon/Wowless/archaeologydigsiteframe.xml
+++ b/addon/Wowless/archaeologydigsiteframe.xml
@@ -1,0 +1,28 @@
+<Ui>
+  <!--
+    issue #863: ArchaeologyDigSiteFrame parses on wow_classic_era,
+    wow_classic_era_ptr, and wow_anniversary (Blizzard ships the same
+    DigSiteDataProvider.xml to every product), but genuinely has no
+    working uiobject on those three products; only a virtual="true"
+    template declaration is ever real client usage. Instantiating it
+    for real, as done here, must warn "Unknown frame type" the same
+    way CreateFrame does for any other bogus type name, then skip
+    creating the frame. wow_classic/wow_classic_ptr have a genuine
+    uiobject backing it instead, and the remaining products never
+    define the tag at all; WowlessData.Xml (the addon's copy of
+    data/products/<product>/xml.yaml, from gentest.lua) reports which
+    case applies on the current product, so this file loads
+    unconditionally everywhere and derives its expectation from that.
+  -->
+  <Script>
+    local tag = _G.WowlessData.Xml.ArchaeologyDigSiteFrame
+    if not tag then
+      table.insert(_G.Wowless.ExpectedNextFrame, 'Unrecognized XML: ArchaeologyDigSiteFrame')
+    elseif tag.impl == 'unknowntype' then
+      table.insert(_G.Wowless.ExpectedNextFrame, 'Unknown frame type: ArchaeologyDigSiteFrame')
+    else
+      assert(type(tag.impl) == 'table' and tag.impl.uiobject, tag.impl)
+    end
+  </Script>
+  <ArchaeologyDigSiteFrame />
+</Ui>

--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -137,6 +137,10 @@ Animations:
     tags:
       AnimationGroup:
   impl: transparent
+ArchaeologyDigSiteFrame:
+  extends: Frame
+  impl:
+    uiobject: ArchaeologyDigSiteFrame
 Attribute:
   attributes:
     name:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -139,8 +139,7 @@ Animations:
   impl: transparent
 ArchaeologyDigSiteFrame:
   extends: Frame
-  impl:
-    uiobject: Frame
+  impl: unknowntype
 Attribute:
   attributes:
     name:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -139,8 +139,7 @@ Animations:
   impl: transparent
 ArchaeologyDigSiteFrame:
   extends: Frame
-  impl:
-    uiobject: Frame
+  impl: unknowntype
 Attribute:
   attributes:
     name:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -139,8 +139,7 @@ Animations:
   impl: transparent
 ArchaeologyDigSiteFrame:
   extends: Frame
-  impl:
-    uiobject: Frame
+  impl: unknowntype
 Attribute:
   attributes:
     name:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -137,6 +137,10 @@ Animations:
     tags:
       AnimationGroup:
   impl: transparent
+ArchaeologyDigSiteFrame:
+  extends: Frame
+  impl:
+    uiobject: ArchaeologyDigSiteFrame
 Attribute:
   attributes:
     name:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -137,6 +137,10 @@ Animations:
     tags:
       AnimationGroup:
   impl: transparent
+ArchaeologyDigSiteFrame:
+  extends: Frame
+  impl:
+    uiobject: ArchaeologyDigSiteFrame
 Attribute:
   attributes:
     name:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -79,6 +79,7 @@ type:
             uiobject:
               ref:
                 schema: uiobjects
+            unknowntype: tag
       phase:
         type:
           taggedunion:

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -584,6 +584,9 @@ local ptablemap = {
   uiobjectapis = function(p)
     return 'UIObjectApis', computeUiobjectApis(p)
   end,
+  xml = function(p)
+    return 'Xml', perproduct(p, 'xml')
+  end,
 }
 
 local args = (function()

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -196,7 +196,7 @@ return function(datalua, eventqueue)
           attr = resultAttrs,
           kids = resultKids,
           line = e._line,
-          rawtype = e._name,
+          name = e._name,
           type = tname,
         }
       end

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -196,6 +196,7 @@ return function(datalua, eventqueue)
           attr = resultAttrs,
           kids = resultKids,
           line = e._line,
+          rawtype = e._name,
           type = tname,
         }
       end

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -749,9 +749,7 @@ return function(
           -- client refuses to instantiate it, the same way it does an
           -- unknown frame type passed to CreateFrame.
           if unknownType then
-            if datalua.config.runtime.warners[ltype] then
-              QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. e.name)
-            end
+            QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. e.name)
             return nil
           end
           local name = e.attr.name

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -638,6 +638,10 @@ return function(
     return type(entry) == 'table' and entry.uiobject and string.lower(entry.uiobject) or nil
   end
 
+  local function implUnknownType(e)
+    return xmlimpls[e.type] and xmlimpls[e.type].tag == 'unknowntype'
+  end
+
   local function loadElements(ctx, t, parent)
     for _, v in ipairs(t) do
       loadElement(ctx, v, parent)
@@ -708,9 +712,10 @@ return function(
     local ltype = string.lower(e.type)
     local intrinsicEntry = intrinsics.Get(ltype)
     local implBasetype = implUiobjectType(e)
+    local unknownType = implUnknownType(e)
     -- e.type dispatches to either a declared uiobject-creating tag (impl.uiobject
     -- in xml.yaml) or a previously-registered intrinsic (same name namespace).
-    if implBasetype or intrinsicEntry then
+    if implBasetype or intrinsicEntry or unknownType then
       ctx = not e.attr.intrinsic and ctx or mixin({}, ctx, { intrinsic = true })
       local template = {
         ctx = ctx,
@@ -737,6 +742,16 @@ return function(
           -- warns on an unknown frame type.
           if intrinsicEntry and intrinsicEntry.nested then
             QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. intrinsicEntry.displayName)
+            return nil
+          end
+          -- issue #863: this tag parses (structurally valid per xml.yaml)
+          -- but has no genuine backing uiobject on this product; a real
+          -- client refuses to instantiate it, the same way it does an
+          -- unknown frame type passed to CreateFrame.
+          if unknownType then
+            if datalua.config.runtime.warners[ltype] then
+              QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. e.rawtype)
+            end
             return nil
           end
           local name = e.attr.name

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -750,7 +750,7 @@ return function(
           -- unknown frame type passed to CreateFrame.
           if unknownType then
             if datalua.config.runtime.warners[ltype] then
-              QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. e.rawtype)
+              QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. e.name)
             end
             return nil
           end


### PR DESCRIPTION
ArchaeologyDigSiteFrame parses on wow_classic_era/wow_classic_era_ptr/
wow_anniversary (Blizzard ships the same DigSiteDataProvider.xml to
every product), but genuinely has no working uiobject there -- only
its virtual="true" template declaration is real client usage. It
previously aliased straight to Frame, so a real (never-exercised)
non-virtual instantiation would silently succeed instead of matching
what CreateFrame does for any other bogus type name.

Adds a `unknowntype` impl arm to xml.yaml's taggedunion; xmleval.lua's
loadElement now warns "Unknown frame type" and skips creation for a
non-virtual tag carrying it, mirroring the existing nested-intrinsic
precedent (issue #116) rather than throwing, so the framework's own
error count stays untouched. xml.lua now also preserves each parsed
element's original-case tag text (rawtype) for that warning's message
text, since the existing `type` field is always lowercased.

The addon-level test (shared with a real client) reads its expectation
straight from WowlessData.Xml (a new raw passthrough of
data/products/<product>/xml.yaml, mirroring existing entries like
Build/Config/CVars/ScriptTypes), so it runs unconditionally on every
product and derives the correct outcome (unknowntype warning, real
uiobject success, or unrecognized-tag warning) from data instead of a
hardcoded product list.

Closes #863.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
