### PR TITLE
gentest,addon: test every XML tag whose impl instantiates a Frame-derived uiobject

### DIFF
--- a/addon/Wowless/generated.lua
+++ b/addon/Wowless/generated.lua
@@ -631,10 +631,39 @@ G.testsuite.generated = function()
     return tests
   end
 
+  -- gentest.lua's discoverFrameTags applies this exact same filter (impl a
+  -- non-singleton uiobject that is-a Frame) to decide which XML tags get a
+  -- <Frames>-wrapped, parentKey'd-by-lowercased-tag-name instantiation in
+  -- templates.xml; mirroring it here means the addon can locate and check
+  -- each one without a dedicated generated data file.
+  local function frametags()
+    local tests = {}
+    for tag, def in pairs(_G.WowlessData.Xml) do
+      local uiobject = type(def.impl) == 'table' and def.impl.uiobject
+      local api = uiobject and _G.WowlessData.UIObjectApis[uiobject]
+      if api and not api.singleton and api.isa.Frame then
+        local key = tag:lower()
+        tests[key] = function()
+          local obj = _G.WowlessGeneratedXmlTests[key]
+          return {
+            isframe = function()
+              assertEquals(true, obj:IsObjectType('Frame'))
+            end,
+            objtype = function()
+              assertEquals(api.objtype, obj:GetObjectType())
+            end,
+          }
+        end
+      end
+    end
+    return tests
+  end
+
   return {
     apiNamespaces = apiNamespaces,
     cvars = cvars,
     events = events,
+    frametags = frametags,
     globalApis = globalApis,
     globals = globals,
     impltests = impltests,

--- a/tools/gentest.lua
+++ b/tools/gentest.lua
@@ -293,6 +293,41 @@ local function discoverCases(p)
   return cases
 end
 
+-- Every XML tag whose impl instantiates a uiobject that is-a Frame
+-- (data/schemas/xml.yaml's impl.uiobject, as opposed to transparent/call/
+-- script/loadstring/unknowntype), excluding singleton types (e.g.
+-- Minimap: the game creates the one true instance itself, and a second
+-- one errors) -- addon/Wowless/generated.lua's frametags() applies this
+-- exact same filter over WowlessData.Xml/UIObjectApis directly, so
+-- there's no dedicated ptablemap entry for it, just this shared list of
+-- tags to instantiate in templates.xml.
+--
+-- Every such tag nests directly under a single <Frames> wrapper: Frame's
+-- own contents only ever offer a Frames child, and Frames accepts any
+-- non-sealed Frame-extending tag generically, including Frame itself
+-- (see frameChains) -- so unlike discoverCases's attribute candidates,
+-- there's no need to walk a containment chain or assign scaffolding
+-- parentKeys, just a fixed one-level nest keyed by the tag's own
+-- (lowercased) name. frameChains is still consulted, and asserted
+-- against that fixed shape, purely to catch a tag becoming unreachable
+-- (e.g. a future `sealed` flag) rather than silently mis-nesting it.
+local function discoverFrameTags(p, uiobjectApis)
+  local chains = frameChains(p)
+  local tags = {}
+  for tag, tdef in pairs(perproduct(p, 'xml')) do
+    local objtype = type(tdef.impl) == 'table' and tdef.impl.uiobject
+    if objtype and not uiobjectApis[objtype].singleton and uiobjectApis[objtype].isa.Frame then
+      local chain = chains[tag]
+      assert(
+        chain and #chain == 3 and chain[2] == 'Frames',
+        ('%s: expected a Frame -> Frames -> %s containment chain'):format(tag, tag)
+      )
+      table.insert(tags, tag)
+    end
+  end
+  return tags
+end
+
 local function attrMembers(p, case)
   local tdef = perproduct(p, 'xml')[case.xmlTag]
   local attrDef = tdef and tdef.attributes[case.xmlAttrKey]
@@ -353,12 +388,14 @@ local function computeCandidates(p, case)
   return candidates
 end
 
--- Builds the WowlessGeneratedXmlTests root shared by the 'templatexml' file
--- (rendered to text as templates.xml) and the templates ptablemap entry.
--- Also appends one non-virtual, self-closing instantiation per XML tag
--- whose impl is 'unknowntype' on this product (see xmleval.lua's
--- loadElement, issue #863) as a sibling top-level element, since those
--- don't need any of the wrapper/nesting machinery above -- just
+-- Builds the WowlessGeneratedXmlTests root shared by the 'templatexml'
+-- file (rendered to text as templates.xml) and the templates ptablemap
+-- entry. Also appends one <Frames>-wrapped, non-virtual, self-closing
+-- instantiation per discoverFrameTags(p) tag (parentKey'd by its own
+-- lowercased name -- see that function), and one bare non-virtual,
+-- self-closing instantiation per XML tag whose impl is 'unknowntype' on
+-- this product (see xmleval.lua's loadElement, issue #863) as a sibling
+-- top-level element, since those don't need any wrapper -- just
 -- somewhere in WowlessData's own XML for xmleval to process before
 -- test.xml runs.
 local function buildTemplatesXml(p, uiobjectApis)
@@ -368,6 +405,9 @@ local function buildTemplatesXml(p, uiobjectApis)
       local key = case.id .. '_' .. c.suffix
       table.insert(root, templateElement(uiobjectApis, case.chain, case.xmlAttrKey, key, c.value))
     end
+  end
+  for _, tag in ipairs(discoverFrameTags(p, uiobjectApis)) do
+    table.insert(root, { tag = 'Frames', { tag = tag, parentKey = tag:lower() } })
   end
   local ui = { root, tag = 'Ui' }
   for name, def in sorted(perproduct(p, 'xml')) do


### PR DESCRIPTION
## Summary
- Extends the unknowntype XML impl test infra (a generated per-product list, checked addon-side against `WowlessData`) to the positive case: every XML tag whose `impl.uiobject` is-a `Frame` (excluding singletons like `Minimap`, which the game creates itself).
- `tools/gentest.lua`'s `discoverFrameTags` finds these tags and, in `buildTemplatesXml`, wraps each in the single fixed `<Frames>` containment shape Frame's own schema allows, keyed by the tag's own lowercased name.
- No new generated data file: `addon/Wowless/generated.lua`'s `frametags()` derives the same tag set directly from `WowlessData.Xml`/`WowlessData.UIObjectApis`, which the addon already has, mirroring gentest.lua's filter instead of consuming a dedicated ptablemap entry — and asserts `GetObjectType()`/`IsObjectType('Frame')` on each instantiated object.

Along the way, an earlier version of this PR reused the general attribute-template chain machinery (`identityHops`/`templateElement`) for this, which surfaced a latent bug: `identityHops` keys a chain's leaf into `uiobjectApis` by XML tag name, silently producing an empty, unaddressable `objectPath` whenever a tag's name differs from its `impl.uiobject` key (e.g. `WorldFrame` -> `Frame`) — the resulting test would have vacuously checked the root frame instead of the real object. Since the actual containment shape for these tags is always fixed (`Frame` -> `Frames` -> tag), the fix was to not reuse that machinery here at all.

## Test plan
- [x] `cmake --build --preset default --target test` passes
- [x] `pre-commit run -a` passes (includes the build-and-test hook)
- [x] Verified the tests actually catch regressions by temporarily corrupting the expected `objtype` check and confirming the build failed per-tag (including `worldframe`, confirming it's checking the real object, not the root), then reverted