### PR TITLE
tools: make xmlcontainment_spec table-driven

### DIFF
--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -1,67 +1,122 @@
 describe('xmlcontainment', function()
   local xmlcontainment = require('tools.xmlcontainment')
 
-  it('finds a direct child', function()
-    local xml = {
-      Frame = { contents = { tags = { Leaf = true } } },
-      Leaf = {},
-    }
-    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'Leaf' }, chains.Leaf)
-    assert.same({}, ambiguous)
-  end)
+  local cases = {
+    ['finds a direct child'] = {
+      xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
+      chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
+    },
+    ['walks through wrapper tags to find the shortest chain'] = {
+      xml = {
+        Frame = { contents = { tags = { Wrap = true } } },
+        Wrap = { contents = { tags = { Leaf = true } } },
+        Leaf = {},
+      },
+      chains = {
+        Frame = { 'Frame' },
+        Wrap = { 'Frame', 'Wrap' },
+        Leaf = { 'Frame', 'Wrap', 'Leaf' },
+      },
+    },
+    ['matches a tag reachable only via its extends chain'] = {
+      xml = {
+        Base = {},
+        Frame = { contents = { tags = { Base = true } } },
+        Sub = { extends = 'Base' },
+      },
+      chains = {
+        Frame = { 'Frame' },
+        Base = { 'Frame', 'Base' },
+        Sub = { 'Frame', 'Sub' },
+      },
+    },
+    ['does not mark a tag reachable if nothing accepts it'] = {
+      xml = { Frame = { contents = { tags = {} } }, Orphan = {} },
+      chains = { Frame = { 'Frame' } },
+    },
+    ['sealed stops extends-chain climbing for containment purposes'] = {
+      xml = {
+        Base = {},
+        Frame = { contents = { tags = { Base = true } } },
+        Sub = { extends = 'Base', sealed = true },
+      },
+      chains = { Frame = { 'Frame' }, Base = { 'Frame', 'Base' } },
+    },
+    ['sealed does not affect a tag reachable via its own declared contents'] = {
+      xml = {
+        Base = {},
+        Frame = { contents = { tags = { Sub = true } } },
+        Sub = { extends = 'Base', sealed = true },
+      },
+      chains = { Frame = { 'Frame' }, Sub = { 'Frame', 'Sub' } },
+    },
+    ['does not mark a tag ambiguous when a second route is strictly deeper'] = {
+      xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        B = { contents = { tags = { Leaf = true } } },
+        C = { contents = { tags = { B = true } } },
+        Frame = { contents = { tags = { A = true, C = true } } },
+        Leaf = {},
+      },
+      chains = {
+        Frame = { 'Frame' },
+        A = { 'Frame', 'A' },
+        C = { 'Frame', 'C' },
+        B = { 'Frame', 'C', 'B' },
+        Leaf = { 'Frame', 'A', 'Leaf' },
+      },
+    },
+    ['preferParent resolves a tie without marking it ambiguous'] = {
+      xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        B = { contents = { tags = { Leaf = true } } },
+        Frame = { contents = { tags = { A = true, B = true } } },
+        Leaf = {},
+      },
+      preferParent = 'B',
+      chains = {
+        Frame = { 'Frame' },
+        A = { 'Frame', 'A' },
+        B = { 'Frame', 'B' },
+        Leaf = { 'Frame', 'B', 'Leaf' },
+      },
+    },
+    ['preferParent does not affect tags with only one candidate'] = {
+      xml = {
+        A = { contents = { tags = { Leaf = true } } },
+        Frame = { contents = { tags = { A = true } } },
+        Leaf = {},
+      },
+      preferParent = 'NeverAppears',
+      chains = {
+        Frame = { 'Frame' },
+        A = { 'Frame', 'A' },
+        Leaf = { 'Frame', 'A', 'Leaf' },
+      },
+    },
+    ['rediscovers the root tag as an ordinary two-hop descendant of itself'] = {
+      xml = {
+        Frame = { contents = { tags = { Wrap = true } } },
+        Wrap = { contents = { tags = { Frame = true } } },
+      },
+      chains = { Frame = { 'Frame', 'Wrap', 'Frame' }, Wrap = { 'Frame', 'Wrap' } },
+    },
+  }
 
-  it('walks through wrapper tags to find the shortest chain', function()
-    local xml = {
-      Frame = { contents = { tags = { Wrap = true } } },
-      Wrap = { contents = { tags = { Leaf = true } } },
-      Leaf = {},
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'Wrap', 'Leaf' }, chains.Leaf)
-  end)
+  for name, case in pairs(cases) do
+    it(name, function()
+      local chains, ambiguous = xmlcontainment.chains(case.xml, 'Frame', case.preferParent)
+      assert.same(case.chains, chains)
+      assert.same({}, ambiguous)
+    end)
+  end
 
-  it('matches a tag reachable only via its extends chain', function()
-    local xml = {
-      Base = {},
-      Frame = { contents = { tags = { Base = true } } },
-      Sub = { extends = 'Base' },
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'Base' }, chains.Base)
-    assert.same({ 'Frame', 'Sub' }, chains.Sub)
-  end)
-
-  it('does not mark a tag reachable if nothing accepts it', function()
-    local xml = {
-      Frame = { contents = { tags = {} } },
-      Orphan = {},
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame')
-    assert.is_nil(chains.Orphan)
-  end)
-
-  it('sealed stops extends-chain climbing for containment purposes', function()
-    local xml = {
-      Base = {},
-      Frame = { contents = { tags = { Base = true } } },
-      Sub = { extends = 'Base', sealed = true },
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'Base' }, chains.Base)
-    assert.is_nil(chains.Sub)
-  end)
-
-  it('sealed does not affect a tag reachable via its own declared contents', function()
-    local xml = {
-      Base = {},
-      Frame = { contents = { tags = { Sub = true } } },
-      Sub = { extends = 'Base', sealed = true },
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'Sub' }, chains.Sub)
-  end)
-
+  -- Not table-driven like the cases above: when two parents are equally
+  -- shallow and no preferParent breaks the tie, xmlcontainment.chains()
+  -- documents that either candidate may be recorded as the winner (Lua's
+  -- table iteration order decides which). The exact winner isn't part of
+  -- the contract, so this asserts the real return value is one of the two
+  -- legitimate answers instead of a fixed one.
   it('marks a tag ambiguous when two equally-shallow parents both accept it', function()
     local xml = {
       A = { contents = { tags = { Leaf = true } } },
@@ -70,51 +125,8 @@ describe('xmlcontainment', function()
       Leaf = {},
     }
     local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
-    assert.is_true(ambiguous.Leaf)
-    assert.is_not_nil(chains.Leaf)
-  end)
-
-  it('does not mark a tag ambiguous when a second route is strictly deeper', function()
-    local xml = {
-      A = { contents = { tags = { Leaf = true } } },
-      B = { contents = { tags = { Leaf = true } } },
-      C = { contents = { tags = { B = true } } },
-      Frame = { contents = { tags = { A = true, C = true } } },
-      Leaf = {},
-    }
-    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
-    assert.is_nil(ambiguous.Leaf)
-  end)
-
-  it('preferParent resolves a tie without marking it ambiguous', function()
-    local xml = {
-      A = { contents = { tags = { Leaf = true } } },
-      B = { contents = { tags = { Leaf = true } } },
-      Frame = { contents = { tags = { A = true, B = true } } },
-      Leaf = {},
-    }
-    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame', 'B')
-    assert.same({ 'Frame', 'B', 'Leaf' }, chains.Leaf)
-    assert.is_nil(ambiguous.Leaf)
-  end)
-
-  it('preferParent does not affect tags with only one candidate', function()
-    local xml = {
-      A = { contents = { tags = { Leaf = true } } },
-      Frame = { contents = { tags = { A = true } } },
-      Leaf = {},
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame', 'NeverAppears')
-    assert.same({ 'Frame', 'A', 'Leaf' }, chains.Leaf)
-  end)
-
-  it('rediscovers the root tag as an ordinary two-hop descendant of itself', function()
-    local xml = {
-      Frame = { contents = { tags = { Wrap = true } } },
-      Wrap = { contents = { tags = { Frame = true } } },
-    }
-    local chains = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ 'Frame', 'Wrap', 'Frame' }, chains.Frame)
+    assert.same({ Leaf = true }, ambiguous)
+    local actual = table.concat(chains.Leaf, '/')
+    assert.same(true, actual == 'Frame/A/Leaf' or actual == 'Frame/B/Leaf')
   end)
 end)


### PR DESCRIPTION
## Summary
- Collapses the near-duplicate `it()` blocks in `spec/tools/xmlcontainment_spec.lua` into one named-case table with a single loop, comparing full `chains`/`ambiguous` return values via `assert.same` instead of per-tag partial checks.
- The one genuinely nondeterministic case (two equally-shallow parents tied, no `preferParent` — see the doc comment in `tools/xmlcontainment.lua`) stays a standalone test asserting the result is one of the two legitimate answers rather than a fixed value, since Lua's table iteration order decides the winner.

## Test plan
- [x] `cmake --build --preset default --target test` — exit code 0, no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015atYCbmdVMZZwvCXMLmj1H