### PR TITLE
spec: table-driven test conversions across the suite

### DIFF
--- a/spec/addon/util_spec.lua
+++ b/spec/addon/util_spec.lua
@@ -5,52 +5,34 @@ describe('util', function()
   describe('assertRecursivelyEqual', function()
     local f = assert(env.assertRecursivelyEqual)
 
-    it('returns nil on equal numbers', function()
-      assert.Nil(f(3, 3))
-    end)
-
-    it('returns nil on equal strings', function()
-      assert.Nil(f('foo', 'foo'))
-    end)
-
-    it('returns nil on equal booleans', function()
-      assert.Nil(f(true, true))
-      assert.Nil(f(false, false))
-    end)
-
-    it('returns nil on nils', function()
-      assert.Nil(f(nil, nil))
-    end)
-
-    it('throws on unequal numbers', function()
-      assert.errors(function()
-        f(3, 4)
+    local equalCases = {
+      numbers = { value = 3 },
+      strings = { value = 'foo' },
+      ['true booleans'] = { value = true },
+      ['false booleans'] = { value = false },
+      nils = { value = nil },
+    }
+    for name, case in pairs(equalCases) do
+      it('returns nil on equal ' .. name, function()
+        assert.Nil(f(case.value, case.value))
       end)
-    end)
+    end
 
-    it('throws on unequal strings', function()
-      assert.errors(function()
-        f('foo', 'bar')
+    local unequalCases = {
+      numbers = { a = 3, b = 4 },
+      strings = { a = 'foo', b = 'bar' },
+      booleans = { a = true, b = false },
+      ['types (number/boolean)'] = { a = 34, b = false },
+      ['types (string/nil)'] = { a = 'foo', b = nil },
+      ['types (string/table)'] = { a = 'bar', b = {} },
+    }
+    for name, case in pairs(unequalCases) do
+      it('throws on unequal ' .. name, function()
+        assert.errors(function()
+          f(case.a, case.b)
+        end)
       end)
-    end)
-
-    it('throws on unequal booleans', function()
-      assert.errors(function()
-        f(true, false)
-      end)
-    end)
-
-    it('throws on unequal types', function()
-      assert.errors(function()
-        f(34, false)
-      end)
-      assert.errors(function()
-        f('foo', nil)
-      end)
-      assert.errors(function()
-        f('bar', {})
-      end)
-    end)
+    end
 
     it('returns empty table on empty tables', function()
       assert.same({}, f({}, {}))

--- a/spec/tools/prettywrite_spec.lua
+++ b/spec/tools/prettywrite_spec.lua
@@ -2,50 +2,50 @@ describe('prettywrite', function()
   local prettywrite = require('tools.prettywrite')
 
   local cases = {
-    { 'false', false, 'false' },
-    { 'true', true, 'true' },
-    { 'integer', 42, '42' },
-    { 'negative integer', -7, '-7' },
-    { 'large integer', 2147483648, '2147483648' },
-    { 'float', 1.5, tostring(1.5) },
-    { 'string', 'hello', '"hello"' },
-    { 'string with quotes', 'say "hi"', '"say \\"hi\\""' },
-    { 'empty table', {}, '{}' },
+    ['false'] = { input = false, expected = 'false' },
+    ['true'] = { input = true, expected = 'true' },
+    integer = { input = 42, expected = '42' },
+    ['negative integer'] = { input = -7, expected = '-7' },
+    ['large integer'] = { input = 2147483648, expected = '2147483648' },
+    float = { input = 1.5, expected = tostring(1.5) },
+    string = { input = 'hello', expected = '"hello"' },
+    ['string with quotes'] = { input = 'say "hi"', expected = '"say \\"hi\\""' },
+    ['empty table'] = { input = {}, expected = '{}' },
   }
 
   local inline_cases = {
-    { 'array', { 1, 2, 3 }, '{1, 2, 3}' },
-    { 'map', { a = 1, b = 2 }, '{a = 1, b = 2}' },
-    { 'non-identifier key', { ['foo-bar'] = 1 }, '{["foo-bar"] = 1}' },
-    { 'numeric non-array key', { [0] = 1 }, '{[0] = 1}' },
-    { 'sorted keys', { c = 3, a = 1, b = 2 }, '{a = 1, b = 2, c = 3}' },
-    { 'keyword key', { ['and'] = 1 }, '{["and"] = 1}' },
+    array = { input = { 1, 2, 3 }, expected = '{1, 2, 3}' },
+    map = { input = { a = 1, b = 2 }, expected = '{a = 1, b = 2}' },
+    ['non-identifier key'] = { input = { ['foo-bar'] = 1 }, expected = '{["foo-bar"] = 1}' },
+    ['numeric non-array key'] = { input = { [0] = 1 }, expected = '{[0] = 1}' },
+    ['sorted keys'] = { input = { c = 3, a = 1, b = 2 }, expected = '{a = 1, b = 2, c = 3}' },
+    ['keyword key'] = { input = { ['and'] = 1 }, expected = '{["and"] = 1}' },
   }
 
   local multiline_cases = {
-    { 'array', { 1, 2 }, '{\n  1,\n  2,\n}' },
-    { 'map', { a = 1, b = 2 }, '{\n  a = 1,\n  b = 2,\n}' },
-    { 'nested', { x = { y = 1 } }, '{\n  x = {\n    y = 1,\n  },\n}' },
+    array = { input = { 1, 2 }, expected = '{\n  1,\n  2,\n}' },
+    map = { input = { a = 1, b = 2 }, expected = '{\n  a = 1,\n  b = 2,\n}' },
+    nested = { input = { x = { y = 1 } }, expected = '{\n  x = {\n    y = 1,\n  },\n}' },
   }
 
-  for _, c in ipairs(cases) do
-    it(c[1], function()
-      assert.equal(c[3], prettywrite(c[2]))
+  for name, c in pairs(cases) do
+    it(name, function()
+      assert.equal(c.expected, prettywrite(c.input))
     end)
   end
 
   describe('inline', function()
-    for _, c in ipairs(inline_cases) do
-      it(c[1], function()
-        assert.equal(c[3], prettywrite(c[2], true))
+    for name, c in pairs(inline_cases) do
+      it(name, function()
+        assert.equal(c.expected, prettywrite(c.input, true))
       end)
     end
   end)
 
   describe('multiline', function()
-    for _, c in ipairs(multiline_cases) do
-      it(c[1], function()
-        assert.equal(c[3], prettywrite(c[2]))
+    for name, c in pairs(multiline_cases) do
+      it(name, function()
+        assert.equal(c.expected, prettywrite(c.input))
       end)
     end
   end)

--- a/spec/wowapi/schema_spec.lua
+++ b/spec/wowapi/schema_spec.lua
@@ -12,107 +12,103 @@ describe('schema', function()
           assert.same(emsg, msg)
         end
     end)()
+    local function runCase(schema, case)
+      if case.error == nil then
+        accept(schema, case.value)
+      else
+        reject(schema, case.value, case.error)
+      end
+    end
     describe('boolean', function()
-      it('rejects nil', function()
-        reject('boolean', nil, 'want boolean, got nil')
-      end)
-      it('rejects numbers', function()
-        reject('boolean', 42, 'want boolean, got number')
-      end)
-      it('accepts booleans', function()
-        accept('boolean', true)
-      end)
-      it('rejects strings', function()
-        reject('boolean', 'foo', 'want boolean, got string')
-      end)
-      it('rejects tables', function()
-        reject('boolean', {}, 'want boolean, got table')
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'want boolean, got nil' },
+        ['rejects numbers'] = { value = 42, error = 'want boolean, got number' },
+        ['accepts booleans'] = { value = true },
+        ['rejects strings'] = { value = 'foo', error = 'want boolean, got string' },
+        ['rejects tables'] = { value = {}, error = 'want boolean, got table' },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase('boolean', case)
+        end)
+      end
     end)
     describe('number', function()
-      it('rejects nil', function()
-        reject('number', nil, 'want number, got nil')
-      end)
-      it('accepts numbers', function()
-        accept('number', 42)
-      end)
-      it('rejects booleans', function()
-        reject('number', true, 'want number, got boolean')
-      end)
-      it('rejects strings', function()
-        reject('number', 'foo', 'want number, got string')
-      end)
-      it('rejects tables', function()
-        reject('number', {}, 'want number, got table')
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'want number, got nil' },
+        ['accepts numbers'] = { value = 42 },
+        ['rejects booleans'] = { value = true, error = 'want number, got boolean' },
+        ['rejects strings'] = { value = 'foo', error = 'want number, got string' },
+        ['rejects tables'] = { value = {}, error = 'want number, got table' },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase('number', case)
+        end)
+      end
     end)
     describe('string', function()
-      it('rejects nil', function()
-        reject('string', nil, 'want string, got nil')
-      end)
-      it('rejects numbers', function()
-        reject('string', 42, 'want string, got number')
-      end)
-      it('rejects booleans', function()
-        reject('string', true, 'want string, got boolean')
-      end)
-      it('accepts strings', function()
-        accept('string', 'foo')
-      end)
-      it('rejects tables', function()
-        reject('string', {}, 'want string, got table')
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'want string, got nil' },
+        ['rejects numbers'] = { value = 42, error = 'want string, got number' },
+        ['rejects booleans'] = { value = true, error = 'want string, got boolean' },
+        ['accepts strings'] = { value = 'foo' },
+        ['rejects tables'] = { value = {}, error = 'want string, got table' },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase('string', case)
+        end)
+      end
     end)
     describe('table', function()
-      it('rejects nil', function()
-        reject('table', nil, 'want table, got nil')
-      end)
-      it('rejects numbers', function()
-        reject('table', 42, 'want table, got number')
-      end)
-      it('rejects booleans', function()
-        reject('table', true, 'want table, got boolean')
-      end)
-      it('rejects strings', function()
-        reject('table', 'foo', 'want table, got string')
-      end)
-      it('accepts tables', function()
-        accept('table', {})
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'want table, got nil' },
+        ['rejects numbers'] = { value = 42, error = 'want table, got number' },
+        ['rejects booleans'] = { value = true, error = 'want table, got boolean' },
+        ['rejects strings'] = { value = 'foo', error = 'want table, got string' },
+        ['accepts tables'] = { value = {} },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase('table', case)
+        end)
+      end
     end)
     describe('flag', function()
-      it('accepts true', function()
-        accept('flag', true)
-      end)
-      it('rejects false', function()
-        reject('flag', false, 'want flag (boolean true), got boolean (false)')
-      end)
-      it('rejects nil', function()
-        reject('flag', nil, 'want flag (boolean true), got nil')
-      end)
-      it('rejects numbers', function()
-        reject('flag', 42, 'want flag (boolean true), got number')
-      end)
-      it('rejects strings', function()
-        reject('flag', 'true', 'want flag (boolean true), got string')
-      end)
-      it('rejects tables', function()
-        reject('flag', {}, 'want flag (boolean true), got table')
-      end)
-      it('works in optional record fields', function()
+      local cases = {
+        ['accepts true'] = { value = true },
+        ['rejects false'] = { value = false, error = 'want flag (boolean true), got boolean (false)' },
+        ['rejects nil'] = { value = nil, error = 'want flag (boolean true), got nil' },
+        ['rejects numbers'] = { value = 42, error = 'want flag (boolean true), got number' },
+        ['rejects strings'] = { value = 'true', error = 'want flag (boolean true), got string' },
+        ['rejects tables'] = { value = {}, error = 'want flag (boolean true), got table' },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase('flag', case)
+        end)
+      end
+      describe('in optional record fields', function()
         local ty = {
           record = {
             optionalFlag = { type = 'flag' },
             other = { type = 'string' },
           },
         }
-        accept(ty, { other = 'test' })
-        accept(ty, { optionalFlag = true, other = 'test' })
-        reject(
-          ty,
-          { optionalFlag = false, other = 'test' },
-          { optionalFlag = 'want flag (boolean true), got boolean (false)' }
-        )
+        local recordCases = {
+          ['works when omitted'] = { value = { other = 'test' } },
+          ['works when true'] = { value = { optionalFlag = true, other = 'test' } },
+          ['rejects when false'] = {
+            value = { optionalFlag = false, other = 'test' },
+            error = { optionalFlag = 'want flag (boolean true), got boolean (false)' },
+          },
+        }
+        for name, case in pairs(recordCases) do
+          it(name, function()
+            runCase(ty, case)
+          end)
+        end
       end)
     end)
     describe('record', function()
@@ -129,54 +125,50 @@ describe('schema', function()
           },
         },
       }
-      it('rejects nil', function()
-        reject(ty, nil, 'expected table')
-      end)
-      it('rejects numbers', function()
-        reject(ty, 42, 'expected table')
-      end)
-      it('rejects booleans', function()
-        reject(ty, true, 'expected table')
-      end)
-      it('rejects strings', function()
-        reject(ty, 'foo', 'expected table')
-      end)
-      it('accepts empty tables', function()
-        accept(ty, {})
-      end)
-      it('accepts all fields', function()
-        accept(ty, {
-          foo = 'foo',
-          bar = 'bar',
-          baz = { quux = 'baz.quux' },
-        })
-      end)
-      it('rejects extra fields', function()
-        reject(ty, {
-          foo = 'foo',
-          bar = 'bar',
-          baz = { quux = 'baz.quux' },
-          extra = 'bad',
-        }, { extra = 'unknown field' })
-      end)
-      it('rejects extra nested fields', function()
-        reject(ty, {
-          foo = 'foo',
-          bar = 'bar',
-          baz = { quux = 'baz.quux', extra = 'bad' },
-        }, { baz = { extra = 'unknown field' } })
-      end)
-      it('handles required fields', function()
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'expected table' },
+        ['rejects numbers'] = { value = 42, error = 'expected table' },
+        ['rejects booleans'] = { value = true, error = 'expected table' },
+        ['rejects strings'] = { value = 'foo', error = 'expected table' },
+        ['accepts empty tables'] = { value = {} },
+        ['accepts all fields'] = {
+          value = { foo = 'foo', bar = 'bar', baz = { quux = 'baz.quux' } },
+        },
+        ['rejects extra fields'] = {
+          value = { foo = 'foo', bar = 'bar', baz = { quux = 'baz.quux' }, extra = 'bad' },
+          error = { extra = 'unknown field' },
+        },
+        ['rejects extra nested fields'] = {
+          value = { foo = 'foo', bar = 'bar', baz = { quux = 'baz.quux', extra = 'bad' } },
+          error = { baz = { extra = 'unknown field' } },
+        },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase(ty, case)
+        end)
+      end
+      describe('required fields', function()
         local rty = {
           record = {
             foo = { type = 'string' },
             bar = { required = true, type = 'string' },
           },
         }
-        reject(rty, {}, { bar = 'missing required field' })
-        reject(rty, { foo = 'foo' }, { bar = 'missing required field' })
-        accept(rty, { bar = 'bar' })
-        accept(rty, { foo = 'foo', bar = 'bar' })
+        local requiredCases = {
+          ['rejects when absent'] = { value = {}, error = { bar = 'missing required field' } },
+          ['rejects when other fields present'] = {
+            value = { foo = 'foo' },
+            error = { bar = 'missing required field' },
+          },
+          ['accepts when present alone'] = { value = { bar = 'bar' } },
+          ['accepts with other fields too'] = { value = { foo = 'foo', bar = 'bar' } },
+        }
+        for name, case in pairs(requiredCases) do
+          it(name, function()
+            runCase(rty, case)
+          end)
+        end
       end)
     end)
     describe('mapof', function()
@@ -197,26 +189,19 @@ describe('schema', function()
           },
         },
       }
-      it('rejects nil', function()
-        reject(mstr, nil, 'expected table')
-        reject(mnest, nil, 'expected table')
-      end)
-      it('rejects numbers', function()
-        reject(mstr, 42, 'expected table')
-        reject(mnest, 42, 'expected table')
-      end)
-      it('rejects booleans', function()
-        reject(mstr, true, 'expected table')
-        reject(mnest, true, 'expected table')
-      end)
-      it('rejects strings', function()
-        reject(mstr, 'foo', 'expected table')
-        reject(mnest, 'foo', 'expected table')
-      end)
-      it('accepts empty tables', function()
-        accept(mstr, {})
-        accept(mnest, {})
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'expected table' },
+        ['rejects numbers'] = { value = 42, error = 'expected table' },
+        ['rejects booleans'] = { value = true, error = 'expected table' },
+        ['rejects strings'] = { value = 'foo', error = 'expected table' },
+        ['accepts empty tables'] = { value = {} },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase(mstr, case)
+          runCase(mnest, case)
+        end)
+      end
       it('rejects non-string keys', function()
         reject(mstr, { [42] = 'cow' }, { [42] = { key = 'want string, got number' } })
         reject(mnest, { moo = { [42] = 'cow' } }, { moo = { value = { [42] = { key = 'want string, got number' } } } })
@@ -234,26 +219,19 @@ describe('schema', function()
     describe('sequenceof', function()
       local sstr = { sequenceof = 'string' }
       local snest = { sequenceof = { sequenceof = 'string' } }
-      it('rejects nil', function()
-        reject(sstr, nil, 'expected table')
-        reject(snest, nil, 'expected table')
-      end)
-      it('rejects numbers', function()
-        reject(sstr, 42, 'expected table')
-        reject(snest, 42, 'expected table')
-      end)
-      it('rejects booleans', function()
-        reject(sstr, true, 'expected table')
-        reject(snest, true, 'expected table')
-      end)
-      it('rejects strings', function()
-        reject(sstr, 'foo', 'expected table')
-        reject(snest, 'foo', 'expected table')
-      end)
-      it('accepts empty tables', function()
-        accept(sstr, {})
-        accept(snest, {})
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'expected table' },
+        ['rejects numbers'] = { value = 42, error = 'expected table' },
+        ['rejects booleans'] = { value = true, error = 'expected table' },
+        ['rejects strings'] = { value = 'foo', error = 'expected table' },
+        ['accepts empty tables'] = { value = {} },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase(sstr, case)
+          runCase(snest, case)
+        end)
+      end
       it('rejects string keys', function()
         reject(sstr, { moo = 'cow' }, { moo = 'expected number' })
         reject(snest, { { moo = 'cow' } }, { { moo = 'expected number' } })
@@ -273,40 +251,39 @@ describe('schema', function()
     end)
     describe('literal', function()
       local ty = { literal = 'foo' }
-      it('rejects nil', function()
-        reject(ty, nil, 'string literal mismatch')
-      end)
-      it('rejects numbers', function()
-        reject(ty, 42, 'string literal mismatch')
-      end)
-      it('rejects booleans', function()
-        reject(ty, true, 'string literal mismatch')
-      end)
-      it('accepts matched string', function()
-        accept(ty, 'foo')
-        reject(ty, 'bar', 'string literal mismatch')
-      end)
-      it('rejects tables', function()
-        reject(ty, {}, 'string literal mismatch')
-      end)
+      local cases = {
+        ['rejects nil'] = { value = nil, error = 'string literal mismatch' },
+        ['rejects numbers'] = { value = 42, error = 'string literal mismatch' },
+        ['rejects booleans'] = { value = true, error = 'string literal mismatch' },
+        ['accepts matched string'] = { value = 'foo' },
+        ['rejects mismatched string'] = { value = 'bar', error = 'string literal mismatch' },
+        ['rejects tables'] = { value = {}, error = 'string literal mismatch' },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase(ty, case)
+        end)
+      end
     end)
     describe('setof', function()
-      it('accepts empty set', function()
-        accept({ setof = 'string' }, {})
-      end)
-      it('accepts non empty set', function()
-        accept({ setof = 'string' }, { a = {}, b = {} })
-      end)
-      it('rejects wrong keys', function()
-        reject({ setof = 'string' }, { [42] = {} }, { [42] = { key = 'want string, got number' } })
-      end)
-      it('rejects wrong values', function()
-        reject(
-          { setof = 'string' },
-          { a = 42, b = { 99 } },
-          { a = { value = 'bad value' }, b = { value = 'bad value' } }
-        )
-      end)
+      local ty = { setof = 'string' }
+      local cases = {
+        ['accepts empty set'] = { value = {} },
+        ['accepts non empty set'] = { value = { a = {}, b = {} } },
+        ['rejects wrong keys'] = {
+          value = { [42] = {} },
+          error = { [42] = { key = 'want string, got number' } },
+        },
+        ['rejects wrong values'] = {
+          value = { a = 42, b = { 99 } },
+          error = { a = { value = 'bad value' }, b = { value = 'bad value' } },
+        },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase(ty, case)
+        end)
+      end
     end)
     describe('taggedunion', function()
       local ty = {
@@ -318,24 +295,22 @@ describe('schema', function()
         },
       }
       local err = 'expected one of {bar, foo}'
-      it('accepts one', function()
-        accept(ty, { bar = 42 })
-      end)
-      it('accepts the other', function()
-        accept(ty, { foo = { 'baz', 'quux' } })
-      end)
-      it('rejects non-table', function()
-        reject(ty, 42, err)
-      end)
-      it('rejects empty', function()
-        reject(ty, {}, 'missing element, ' .. err)
-      end)
-      it('rejects multiple', function()
-        reject(ty, { bar = 42, foo = { 'baz', 'quux' } }, 'multiple elements, ' .. err)
-      end)
-      it('rejects bad keys', function()
-        reject(ty, { baz = 99 }, 'bad key, ' .. err)
-      end)
+      local cases = {
+        ['accepts one'] = { value = { bar = 42 } },
+        ['accepts the other'] = { value = { foo = { 'baz', 'quux' } } },
+        ['rejects non-table'] = { value = 42, error = err },
+        ['rejects empty'] = { value = {}, error = 'missing element, ' .. err },
+        ['rejects multiple'] = {
+          value = { bar = 42, foo = { 'baz', 'quux' } },
+          error = 'multiple elements, ' .. err,
+        },
+        ['rejects bad keys'] = { value = { baz = 99 }, error = 'bad key, ' .. err },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          runCase(ty, case)
+        end)
+      end
     end)
   end)
 end)

--- a/spec/wowless/modules/xml_spec.lua
+++ b/spec/wowless/modules/xml_spec.lua
@@ -15,22 +15,34 @@ describe('xml', function()
       -- ButtonText/NormalFont share a type (FontString/Font) with generic
       -- layered regions but belong to Button's own substitution group, not
       -- the generic one -- see issue #778.
-      it('rejects a Button-only child nested in an unrelated container', function()
-        local _, warnings = parse('<Ui><SimpleHTML><ButtonText/></SimpleHTML></Ui>')
-        assert(hasWarning(warnings, 'buttontext cannot be a child of simplehtml'))
-      end)
-      it('rejects a Button-only child at the document root', function()
-        local _, warnings = parse('<Ui><NormalFont/></Ui>')
-        assert(hasWarning(warnings, 'normalfont cannot be a child of ui'))
-      end)
-      it('still accepts those tags under their real parent', function()
-        local _, warnings = parse('<Ui><Button><ButtonText/><NormalFont/></Button></Ui>')
-        assert.False(hasWarning(warnings, 'cannot be a child of'))
-      end)
-      it('still accepts a plain FontString wherever generic layered regions go', function()
-        local _, warnings = parse('<Ui><SimpleHTML><FontString/></SimpleHTML></Ui>')
-        assert.False(hasWarning(warnings, 'cannot be a child of'))
-      end)
+      local cases = {
+        ['rejects a Button-only child nested in an unrelated container'] = {
+          xml = '<Ui><SimpleHTML><ButtonText/></SimpleHTML></Ui>',
+          pattern = 'buttontext cannot be a child of simplehtml',
+          expectWarning = true,
+        },
+        ['rejects a Button-only child at the document root'] = {
+          xml = '<Ui><NormalFont/></Ui>',
+          pattern = 'normalfont cannot be a child of ui',
+          expectWarning = true,
+        },
+        ['still accepts those tags under their real parent'] = {
+          xml = '<Ui><Button><ButtonText/><NormalFont/></Button></Ui>',
+          pattern = 'cannot be a child of',
+          expectWarning = false,
+        },
+        ['still accepts a plain FontString wherever generic layered regions go'] = {
+          xml = '<Ui><SimpleHTML><FontString/></SimpleHTML></Ui>',
+          pattern = 'cannot be a child of',
+          expectWarning = false,
+        },
+      }
+      for name, case in pairs(cases) do
+        it(name, function()
+          local _, warnings = parse(case.xml)
+          assert.same(case.expectWarning, hasWarning(warnings, case.pattern))
+        end)
+      end
     end)
   end
 end)

--- a/spec/wowless/util_spec.lua
+++ b/spec/wowless/util_spec.lua
@@ -20,21 +20,25 @@ describe('util', function()
   describe('readfile', function()
     local readfile = util.readfile
     local path = require('path')
-    it('reads filenames with no path parts', function()
-      assert.Not.Nil(readfile('README.md'))
-    end)
+    local readme = readfile('README.md')
+
+    local readmeCases = {
+      ['filenames with no path parts'] = 'README.md',
+      ['relative paths with dot slash'] = './././././README.md',
+      ['absolute paths'] = path.join(path.currentdir(), 'README.md'),
+      ['filenames case insensitively'] = 'readme.md',
+    }
+    for name, p in pairs(readmeCases) do
+      it('reads ' .. name, function()
+        assert.same(readme, readfile(p))
+      end)
+    end
+
     it('reads relative paths', function()
-      assert.Not.Nil(readfile('spec/wowless/util_spec.lua'))
+      local absolute = readfile(path.join(path.currentdir(), 'spec/wowless/util_spec.lua'))
+      assert.same(absolute, readfile('spec/wowless/util_spec.lua'))
     end)
-    it('reads relative paths with dot slash', function()
-      assert.Not.Nil(readfile('./././././README.md'))
-    end)
-    it('reads absolute paths', function()
-      assert.Not.Nil(readfile(path.join(path.currentdir(), 'README.md')))
-    end)
-    it('reads filenames case insensitively', function()
-      assert.Not.Nil(readfile('readme.md'))
-    end)
+
     it('does not just stop at a good filename', function()
       assert.has.errors(function()
         readfile('README.md/foo')


### PR DESCRIPTION
## Summary
Follow-up to #878, applying the same table-driven refactor to the rest of the clusters identified during that review:
- `spec/addon/util_spec.lua`: assertRecursivelyEqual equal/unequal clusters
- `spec/wowless/modules/xml_spec.lua`: per-product containment-warning clusters
- `spec/wowless/util_spec.lua`: readfile path-form variants, using content-equality against a canonical read instead of bare not-nil
- `spec/tools/prettywrite_spec.lua`: was already table-driven, switched from positional `c[1]/c[2]/c[3]` to named fields
- `spec/wowapi/schema_spec.lua`: the big one — boolean/number/string/table/flag/record/mapof/sequenceof/literal/setof/taggedunion accept/reject clusters collapsed through a shared `runCase` helper; a few genuinely bespoke nested-error-shape tests (mapof/sequenceof key/value edge cases) were left as direct calls rather than forced into the uniform shape

## Test plan
- [x] `cmake --build --preset default --target test` — exit code 0, no output (verified after each commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015atYCbmdVMZZwvCXMLmj1H