### PR TITLE
xml: virtual tags get no xmlflat entry and no dead check

### DIFF
--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -384,63 +384,74 @@ end)()
 local xmlflat = (function()
   local tree = xmlraw
   local newtree = {}
+  -- A virtual tag (e.g. LayoutFrame) is an abstract type real tags extend,
+  -- never a concrete element a real client accepts written out on its own
+  -- -- so it gets no entry here at all. xml.lua's run() looks tag names up
+  -- in this table alone (lang[tname], with no fallback to xmlraw), so
+  -- omitting it here is enough on its own to make a literal <LayoutFrame/>
+  -- fall into the same "Unrecognized XML" handling as any other tag name
+  -- it's never heard of -- no separate check needed. Climbing below reads
+  -- `tree` (xmlraw), not `newtree`, so a real tag extending a virtual one
+  -- still resolves its own flattened supertypes/children/attributes fine.
   for k, v in pairs(tree) do
-    local attrs = {}
-    local warnsinvalid = {}
-    for ak, av in pairs(v.attributes or {}) do
-      attrs[ak] = av.type
-      if av.warnsoninvalid then
-        warnsinvalid[ak] = true
-      end
-    end
-    local kids = {}
-    local text = false
-    if v.contents == 'text' then
-      text = true
-    elseif v.contents then
-      for kid in pairs(v.contents.tags) do
-        local key = kid:lower()
-        assert(not kids[key], kid .. ' is already a child of ' .. k)
-        kids[key] = true
-      end
-    end
-    -- supertypes stops climbing at a sealed tag: extends is type inheritance,
-    -- not substitution-group membership, and some tags share a type with a
-    -- generic tag while only being legal in a narrower spot -- issue #778
-    local supertypes = { [k:lower()] = true }
-    local climbing = not v.sealed
-    local t = v
-    while t.extends do
-      if climbing then
-        supertypes[t.extends:lower()] = true
-      end
-      t = tree[t.extends]
-      climbing = climbing and not t.sealed
-      for ak, av in pairs(t.attributes or {}) do
+    if not v.virtual then
+      local attrs = {}
+      local warnsinvalid = {}
+      for ak, av in pairs(v.attributes or {}) do
         attrs[ak] = av.type
         if av.warnsoninvalid then
           warnsinvalid[ak] = true
         end
       end
-      if t.contents == 'text' then
+      local kids = {}
+      local text = false
+      if v.contents == 'text' then
         text = true
-      elseif t.contents then
-        for kid in pairs(t.contents.tags) do
+      elseif v.contents then
+        for kid in pairs(v.contents.tags) do
           local key = kid:lower()
           assert(not kids[key], kid .. ' is already a child of ' .. k)
           kids[key] = true
         end
       end
+      -- supertypes stops climbing at a sealed tag: extends is type inheritance,
+      -- not substitution-group membership, and some tags share a type with a
+      -- generic tag while only being legal in a narrower spot -- issue #778
+      local supertypes = { [k:lower()] = true }
+      local climbing = not v.sealed
+      local t = v
+      while t.extends do
+        if climbing then
+          supertypes[t.extends:lower()] = true
+        end
+        t = tree[t.extends]
+        climbing = climbing and not t.sealed
+        for ak, av in pairs(t.attributes or {}) do
+          attrs[ak] = av.type
+          if av.warnsoninvalid then
+            warnsinvalid[ak] = true
+          end
+        end
+        if t.contents == 'text' then
+          text = true
+        elseif t.contents then
+          for kid in pairs(t.contents.tags) do
+            local key = kid:lower()
+            assert(not kids[key], kid .. ' is already a child of ' .. k)
+            kids[key] = true
+          end
+        end
+      end
+      assert(not v.sealed or v.extends, k .. ' is sealed but has no extends')
+      assert(not text or #kids == 0, 'both text and kids on ' .. k)
+      newtree[k:lower()] = {
+        attributes = attrs,
+        children = kids,
+        supertypes = supertypes,
+        text = text,
+        warnsinvalid = warnsinvalid,
+      }
     end
-    assert(not v.sealed or v.extends, k .. ' is sealed but has no extends')
-    assert(not text or #kids == 0, 'both text and kids on ' .. k)
-    newtree[k:lower()] = {
-      attributes = attrs,
-      children = kids,
-      supertypes = supertypes,
-      text = text,
-      warnsinvalid = warnsinvalid,
-    }
   end
   return newtree
 end)()

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -384,15 +384,6 @@ end)()
 local xmlflat = (function()
   local tree = xmlraw
   local newtree = {}
-  -- A virtual tag (e.g. LayoutFrame) is an abstract type real tags extend,
-  -- never a concrete element a real client accepts written out on its own
-  -- -- so it gets no entry here at all. xml.lua's run() looks tag names up
-  -- in this table alone (lang[tname], with no fallback to xmlraw), so
-  -- omitting it here is enough on its own to make a literal <LayoutFrame/>
-  -- fall into the same "Unrecognized XML" handling as any other tag name
-  -- it's never heard of -- no separate check needed. Climbing below reads
-  -- `tree` (xmlraw), not `newtree`, so a real tag extending a virtual one
-  -- still resolves its own flattened supertypes/children/attributes fine.
   for k, v in pairs(tree) do
     if not v.virtual then
       local attrs = {}

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -121,9 +121,6 @@ return function(datalua, eventqueue)
         warnUnrecognized(e)
         return nil
       end
-      if ty.virtual then
-        error(tname .. ' is virtual and cannot be instantiated')
-      end
       local extends = false
       for k in pairs(tk) do
         extends = extends or ty.supertypes[k]


### PR DESCRIPTION
## Summary
- Deletes `wowless/modules/xml.lua`'s `if ty.virtual then error(...) end` check. It was unreachable: `run()` reads `ty` off `datalua.xmlflat`, and `tools/prep.lua`'s `xmlflat` builder never copied the schema's `virtual` flag onto the entries it produced -- so `ty.virtual` was always `nil`.
- `tools/prep.lua`'s `xmlflat` builder now skips virtual tags (`LayoutFrame`, `POIFrame`, `ButtonFont`, `Dimension`, `Insets`, `ScriptType`) entirely rather than giving them an entry indistinguishable from a real tag's. Since `xml.lua`'s `run()` looks tag names up in this table alone, omitting a virtual tag here is enough by itself to route a literal `<LayoutFrame/>` into the exact same `Unrecognized XML: %s` handling any other unrecognized tag name gets -- no new check needed. The `extends`-chain climbing inside the same builder reads the raw (unflattened) tree directly, not this table, so a real tag extending a virtual one (`Frame extends LayoutFrame`) is unaffected.

Found while working on #877: a probe showed `<LayoutFrame/>` -- an abstract-only, schema-`virtual` tag -- placed directly under `<Ui>` parsed and was silently accepted, no error, no warning, despite the (dead) check in `run()` looking like it should have caught this.

## Test plan
- [x] `cmake --build --preset default --target test` passes
- [x] `pre-commit run -a` passes (includes the build-and-test hook)
- [x] Verified the fix directly: `<LayoutFrame/>` under `<Ui>` now produces a real `Unrecognized XML: LayoutFrame` warning
- [x] Verified zero blast radius: grepped the real extracted FrameXML and the test addon's own fixtures for literal use of any of the 6 virtual tag names -- zero hits, anywhere. A full product run's `Unrecognized XML` warning count is unchanged (12, all pre-existing, all from the test addon's own intrinsic-type fixtures, unrelated to this change)