### PR TITLE
xml: derive document-root tags from data instead of hardcoding

### DIFF
--- a/data/products/wow/xml.yaml
+++ b/data/products/wow/xml.yaml
@@ -189,6 +189,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1573,6 +1574,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1581,6 +1583,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wow_anniversary/xml.yaml
+++ b/data/products/wow_anniversary/xml.yaml
@@ -188,6 +188,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1548,6 +1549,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1556,6 +1558,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wow_classic/xml.yaml
+++ b/data/products/wow_classic/xml.yaml
@@ -189,6 +189,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1555,6 +1556,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1563,6 +1565,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wow_classic_era/xml.yaml
+++ b/data/products/wow_classic_era/xml.yaml
@@ -188,6 +188,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1543,6 +1544,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1551,6 +1553,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wow_classic_era_ptr/xml.yaml
+++ b/data/products/wow_classic_era_ptr/xml.yaml
@@ -188,6 +188,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1548,6 +1549,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1556,6 +1558,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wow_classic_ptr/xml.yaml
+++ b/data/products/wow_classic_ptr/xml.yaml
@@ -189,6 +189,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1555,6 +1556,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1563,6 +1565,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wowt/xml.yaml
+++ b/data/products/wowt/xml.yaml
@@ -189,6 +189,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1573,6 +1574,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1581,6 +1583,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/products/wowxptr/xml.yaml
+++ b/data/products/wowxptr/xml.yaml
@@ -189,6 +189,7 @@ Bindings:
       Binding:
       ModifiedClick:
   impl: transparent
+  root: true
 BlingTexture:
   extends: Texture
   sealed: true
@@ -1539,6 +1540,7 @@ Ui:
       ScopedModifier:
       Script:
   impl: transparent
+  root: true
 UnitPositionFrame:
   extends: Frame
   impl:
@@ -1547,6 +1549,7 @@ Value:
   contents:
     tags:
       AbsValue:
+  virtual: true
 ViewInsets:
   attributes:
     bottom:

--- a/data/schemas/xml.yaml
+++ b/data/schemas/xml.yaml
@@ -84,6 +84,8 @@ type:
         type:
           taggedunion:
             late: tag
+      root:
+        type: flag
       sealed:
         type: flag
       virtual:

--- a/spec/data/xml_spec.lua
+++ b/spec/data/xml_spec.lua
@@ -1,9 +1,11 @@
 describe('xml', function()
+  local structuralRoots = require('tools.xmlcontainment').roots
   for _, p in ipairs(require('build.data.products')) do
     describe(p, function()
       local xml = require('build.data.products.' .. p .. '.xml')
       local uiobjects = require('build.data.products.' .. p .. '.uiobjects')
       local scripttypes = require('build.data.products.' .. p .. '.scripttypes')
+      local roots = structuralRoots(xml)
       local methods = {}
       local fields = {}
       local function flatten(k)
@@ -44,6 +46,13 @@ describe('xml', function()
       end
       for name, elem in pairs(xml) do
         describe(name, function()
+          -- `root` on an xml.yaml tag is only meaningful if it exactly
+          -- tracks whether the tag is actually never a legal child of any
+          -- other tag -- see wowless/modules/xml.lua's use of the `root`
+          -- flag to build its document-root whitelist.
+          it('root flag matches structural root-ness', function()
+            assert.equals(not not elem.root, not not roots[name])
+          end)
           if elem.extends == 'ScriptType' then
             it('is in scripttypes', function()
               assert.Not.Nil(scripttypes[name])

--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -129,4 +129,41 @@ describe('xmlcontainment', function()
     local actual = table.concat(chains.Leaf, '/')
     assert.same(true, actual == 'Frame/A/Leaf' or actual == 'Frame/B/Leaf')
   end)
+
+  describe('roots', function()
+    it('finds a tag nothing else ever admits as a child', function()
+      local xml = {
+        Frame = { contents = { tags = { Leaf = true } } },
+        Leaf = {},
+      }
+      assert.same({ Frame = true }, xmlcontainment.roots(xml))
+    end)
+
+    it('excludes a tag reachable only via its extends chain', function()
+      local xml = {
+        Base = {},
+        Frame = { contents = { tags = { Base = true } } },
+        Sub = { extends = 'Base' },
+      }
+      assert.same({ Frame = true }, xmlcontainment.roots(xml))
+    end)
+
+    it('excludes a virtual tag even though nothing names it as a child', function()
+      local xml = {
+        Abstract = { virtual = true },
+        Frame = { contents = { tags = { Leaf = true } } },
+        Leaf = {},
+      }
+      assert.same({ Frame = true }, xmlcontainment.roots(xml))
+    end)
+
+    it('sealed stops extends-chain climbing, so the child stays a root', function()
+      local xml = {
+        Base = {},
+        Frame = { contents = { tags = { Base = true } } },
+        Sub = { extends = 'Base', sealed = true },
+      }
+      assert.same({ Frame = true, Sub = true }, xmlcontainment.roots(xml))
+    end)
+  end)
 end)

--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -1,133 +1,135 @@
 describe('xmlcontainment', function()
   local xmlcontainment = require('tools.xmlcontainment')
 
-  local cases = {
-    ['finds a direct child'] = {
-      xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
-      chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
-    },
-    ['walks through wrapper tags to find the shortest chain'] = {
-      xml = {
-        Frame = { contents = { tags = { Wrap = true } } },
-        Wrap = { contents = { tags = { Leaf = true } } },
-        Leaf = {},
+  describe('chains', function()
+    local cases = {
+      ['finds a direct child'] = {
+        xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
+        chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
       },
-      chains = {
-        Frame = { 'Frame' },
-        Wrap = { 'Frame', 'Wrap' },
-        Leaf = { 'Frame', 'Wrap', 'Leaf' },
+      ['walks through wrapper tags to find the shortest chain'] = {
+        xml = {
+          Frame = { contents = { tags = { Wrap = true } } },
+          Wrap = { contents = { tags = { Leaf = true } } },
+          Leaf = {},
+        },
+        chains = {
+          Frame = { 'Frame' },
+          Wrap = { 'Frame', 'Wrap' },
+          Leaf = { 'Frame', 'Wrap', 'Leaf' },
+        },
       },
-    },
-    ['matches a tag reachable only via its extends chain'] = {
-      xml = {
-        Base = {},
-        Frame = { contents = { tags = { Base = true } } },
-        Sub = { extends = 'Base' },
+      ['matches a tag reachable only via its extends chain'] = {
+        xml = {
+          Base = {},
+          Frame = { contents = { tags = { Base = true } } },
+          Sub = { extends = 'Base' },
+        },
+        chains = {
+          Frame = { 'Frame' },
+          Base = { 'Frame', 'Base' },
+          Sub = { 'Frame', 'Sub' },
+        },
       },
-      chains = {
-        Frame = { 'Frame' },
-        Base = { 'Frame', 'Base' },
-        Sub = { 'Frame', 'Sub' },
+      ['does not mark a tag reachable if nothing accepts it'] = {
+        xml = { Frame = { contents = { tags = {} } }, Orphan = {} },
+        chains = { Frame = { 'Frame' } },
       },
-    },
-    ['does not mark a tag reachable if nothing accepts it'] = {
-      xml = { Frame = { contents = { tags = {} } }, Orphan = {} },
-      chains = { Frame = { 'Frame' } },
-    },
-    ['sealed stops extends-chain climbing for containment purposes'] = {
-      xml = {
-        Base = {},
-        Frame = { contents = { tags = { Base = true } } },
-        Sub = { extends = 'Base', sealed = true },
+      ['sealed stops extends-chain climbing for containment purposes'] = {
+        xml = {
+          Base = {},
+          Frame = { contents = { tags = { Base = true } } },
+          Sub = { extends = 'Base', sealed = true },
+        },
+        chains = { Frame = { 'Frame' }, Base = { 'Frame', 'Base' } },
       },
-      chains = { Frame = { 'Frame' }, Base = { 'Frame', 'Base' } },
-    },
-    ['sealed does not affect a tag reachable via its own declared contents'] = {
-      xml = {
-        Base = {},
-        Frame = { contents = { tags = { Sub = true } } },
-        Sub = { extends = 'Base', sealed = true },
+      ['sealed does not affect a tag reachable via its own declared contents'] = {
+        xml = {
+          Base = {},
+          Frame = { contents = { tags = { Sub = true } } },
+          Sub = { extends = 'Base', sealed = true },
+        },
+        chains = { Frame = { 'Frame' }, Sub = { 'Frame', 'Sub' } },
       },
-      chains = { Frame = { 'Frame' }, Sub = { 'Frame', 'Sub' } },
-    },
-    ['does not mark a tag ambiguous when a second route is strictly deeper'] = {
-      xml = {
-        A = { contents = { tags = { Leaf = true } } },
-        B = { contents = { tags = { Leaf = true } } },
-        C = { contents = { tags = { B = true } } },
-        Frame = { contents = { tags = { A = true, C = true } } },
-        Leaf = {},
+      ['does not mark a tag ambiguous when a second route is strictly deeper'] = {
+        xml = {
+          A = { contents = { tags = { Leaf = true } } },
+          B = { contents = { tags = { Leaf = true } } },
+          C = { contents = { tags = { B = true } } },
+          Frame = { contents = { tags = { A = true, C = true } } },
+          Leaf = {},
+        },
+        chains = {
+          Frame = { 'Frame' },
+          A = { 'Frame', 'A' },
+          C = { 'Frame', 'C' },
+          B = { 'Frame', 'C', 'B' },
+          Leaf = { 'Frame', 'A', 'Leaf' },
+        },
       },
-      chains = {
-        Frame = { 'Frame' },
-        A = { 'Frame', 'A' },
-        C = { 'Frame', 'C' },
-        B = { 'Frame', 'C', 'B' },
-        Leaf = { 'Frame', 'A', 'Leaf' },
+      ['preferParent resolves a tie without marking it ambiguous'] = {
+        xml = {
+          A = { contents = { tags = { Leaf = true } } },
+          B = { contents = { tags = { Leaf = true } } },
+          Frame = { contents = { tags = { A = true, B = true } } },
+          Leaf = {},
+        },
+        preferParent = 'B',
+        chains = {
+          Frame = { 'Frame' },
+          A = { 'Frame', 'A' },
+          B = { 'Frame', 'B' },
+          Leaf = { 'Frame', 'B', 'Leaf' },
+        },
       },
-    },
-    ['preferParent resolves a tie without marking it ambiguous'] = {
-      xml = {
+      ['preferParent does not affect tags with only one candidate'] = {
+        xml = {
+          A = { contents = { tags = { Leaf = true } } },
+          Frame = { contents = { tags = { A = true } } },
+          Leaf = {},
+        },
+        preferParent = 'NeverAppears',
+        chains = {
+          Frame = { 'Frame' },
+          A = { 'Frame', 'A' },
+          Leaf = { 'Frame', 'A', 'Leaf' },
+        },
+      },
+      ['rediscovers the root tag as an ordinary two-hop descendant of itself'] = {
+        xml = {
+          Frame = { contents = { tags = { Wrap = true } } },
+          Wrap = { contents = { tags = { Frame = true } } },
+        },
+        chains = { Frame = { 'Frame', 'Wrap', 'Frame' }, Wrap = { 'Frame', 'Wrap' } },
+      },
+    }
+
+    for name, case in pairs(cases) do
+      it(name, function()
+        local chains, ambiguous = xmlcontainment.chains(case.xml, 'Frame', case.preferParent)
+        assert.same(case.chains, chains)
+        assert.same({}, ambiguous)
+      end)
+    end
+
+    -- Not table-driven like the cases above: when two parents are equally
+    -- shallow and no preferParent breaks the tie, xmlcontainment.chains()
+    -- documents that either candidate may be recorded as the winner (Lua's
+    -- table iteration order decides which). The exact winner isn't part of
+    -- the contract, so this asserts the real return value is one of the two
+    -- legitimate answers instead of a fixed one.
+    it('marks a tag ambiguous when two equally-shallow parents both accept it', function()
+      local xml = {
         A = { contents = { tags = { Leaf = true } } },
         B = { contents = { tags = { Leaf = true } } },
         Frame = { contents = { tags = { A = true, B = true } } },
         Leaf = {},
-      },
-      preferParent = 'B',
-      chains = {
-        Frame = { 'Frame' },
-        A = { 'Frame', 'A' },
-        B = { 'Frame', 'B' },
-        Leaf = { 'Frame', 'B', 'Leaf' },
-      },
-    },
-    ['preferParent does not affect tags with only one candidate'] = {
-      xml = {
-        A = { contents = { tags = { Leaf = true } } },
-        Frame = { contents = { tags = { A = true } } },
-        Leaf = {},
-      },
-      preferParent = 'NeverAppears',
-      chains = {
-        Frame = { 'Frame' },
-        A = { 'Frame', 'A' },
-        Leaf = { 'Frame', 'A', 'Leaf' },
-      },
-    },
-    ['rediscovers the root tag as an ordinary two-hop descendant of itself'] = {
-      xml = {
-        Frame = { contents = { tags = { Wrap = true } } },
-        Wrap = { contents = { tags = { Frame = true } } },
-      },
-      chains = { Frame = { 'Frame', 'Wrap', 'Frame' }, Wrap = { 'Frame', 'Wrap' } },
-    },
-  }
-
-  for name, case in pairs(cases) do
-    it(name, function()
-      local chains, ambiguous = xmlcontainment.chains(case.xml, 'Frame', case.preferParent)
-      assert.same(case.chains, chains)
-      assert.same({}, ambiguous)
+      }
+      local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
+      assert.same({ Leaf = true }, ambiguous)
+      local actual = table.concat(chains.Leaf, '/')
+      assert.same(true, actual == 'Frame/A/Leaf' or actual == 'Frame/B/Leaf')
     end)
-  end
-
-  -- Not table-driven like the cases above: when two parents are equally
-  -- shallow and no preferParent breaks the tie, xmlcontainment.chains()
-  -- documents that either candidate may be recorded as the winner (Lua's
-  -- table iteration order decides which). The exact winner isn't part of
-  -- the contract, so this asserts the real return value is one of the two
-  -- legitimate answers instead of a fixed one.
-  it('marks a tag ambiguous when two equally-shallow parents both accept it', function()
-    local xml = {
-      A = { contents = { tags = { Leaf = true } } },
-      B = { contents = { tags = { Leaf = true } } },
-      Frame = { contents = { tags = { A = true, B = true } } },
-      Leaf = {},
-    }
-    local chains, ambiguous = xmlcontainment.chains(xml, 'Frame')
-    assert.same({ Leaf = true }, ambiguous)
-    local actual = table.concat(chains.Leaf, '/')
-    assert.same(true, actual == 'Frame/A/Leaf' or actual == 'Frame/B/Leaf')
   end)
 
   describe('roots', function()
@@ -137,7 +139,7 @@ describe('xmlcontainment', function()
     -- containment, extends-based substitution, sealed truncating that
     -- substitution, virtual overriding reachability, and the everything-
     -- nests-in-everything-else edge case where no tag is a root at all.
-    local rootsCases = {
+    local cases = {
       ['finds a tag nothing else ever admits as a child'] = {
         xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
         roots = { Frame = true },
@@ -175,7 +177,7 @@ describe('xmlcontainment', function()
       },
     }
 
-    for name, case in pairs(rootsCases) do
+    for name, case in pairs(cases) do
       it(name, function()
         assert.same(case.roots, xmlcontainment.roots(case.xml))
       end)

--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -5,6 +5,7 @@ describe('xmlcontainment', function()
     ['finds a direct child'] = {
       xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
       chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
+      roots = { Frame = true },
     },
     ['walks through wrapper tags to find the shortest chain'] = {
       xml = {
@@ -17,6 +18,7 @@ describe('xmlcontainment', function()
         Wrap = { 'Frame', 'Wrap' },
         Leaf = { 'Frame', 'Wrap', 'Leaf' },
       },
+      roots = { Frame = true },
     },
     ['matches a tag reachable only via its extends chain'] = {
       xml = {
@@ -29,10 +31,12 @@ describe('xmlcontainment', function()
         Base = { 'Frame', 'Base' },
         Sub = { 'Frame', 'Sub' },
       },
+      roots = { Frame = true },
     },
     ['does not mark a tag reachable if nothing accepts it'] = {
       xml = { Frame = { contents = { tags = {} } }, Orphan = {} },
       chains = { Frame = { 'Frame' } },
+      roots = { Frame = true, Orphan = true },
     },
     ['sealed stops extends-chain climbing for containment purposes'] = {
       xml = {
@@ -41,6 +45,7 @@ describe('xmlcontainment', function()
         Sub = { extends = 'Base', sealed = true },
       },
       chains = { Frame = { 'Frame' }, Base = { 'Frame', 'Base' } },
+      roots = { Frame = true, Sub = true },
     },
     ['sealed does not affect a tag reachable via its own declared contents'] = {
       xml = {
@@ -49,6 +54,16 @@ describe('xmlcontainment', function()
         Sub = { extends = 'Base', sealed = true },
       },
       chains = { Frame = { 'Frame' }, Sub = { 'Frame', 'Sub' } },
+      roots = { Frame = true, Base = true },
+    },
+    ['excludes a virtual tag even though nothing names it as a child'] = {
+      xml = {
+        Abstract = { virtual = true },
+        Frame = { contents = { tags = { Leaf = true } } },
+        Leaf = {},
+      },
+      chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
+      roots = { Frame = true },
     },
     ['does not mark a tag ambiguous when a second route is strictly deeper'] = {
       xml = {
@@ -65,6 +80,7 @@ describe('xmlcontainment', function()
         B = { 'Frame', 'C', 'B' },
         Leaf = { 'Frame', 'A', 'Leaf' },
       },
+      roots = { Frame = true },
     },
     ['preferParent resolves a tie without marking it ambiguous'] = {
       xml = {
@@ -80,6 +96,7 @@ describe('xmlcontainment', function()
         B = { 'Frame', 'B' },
         Leaf = { 'Frame', 'B', 'Leaf' },
       },
+      roots = { Frame = true },
     },
     ['preferParent does not affect tags with only one candidate'] = {
       xml = {
@@ -93,13 +110,17 @@ describe('xmlcontainment', function()
         A = { 'Frame', 'A' },
         Leaf = { 'Frame', 'A', 'Leaf' },
       },
+      roots = { Frame = true },
     },
+    -- Neither tag is a root here: each is only ever legal nested inside the
+    -- other, so this schema fragment alone has no valid document root.
     ['rediscovers the root tag as an ordinary two-hop descendant of itself'] = {
       xml = {
         Frame = { contents = { tags = { Wrap = true } } },
         Wrap = { contents = { tags = { Frame = true } } },
       },
       chains = { Frame = { 'Frame', 'Wrap', 'Frame' }, Wrap = { 'Frame', 'Wrap' } },
+      roots = {},
     },
   }
 
@@ -108,6 +129,7 @@ describe('xmlcontainment', function()
       local chains, ambiguous = xmlcontainment.chains(case.xml, 'Frame', case.preferParent)
       assert.same(case.chains, chains)
       assert.same({}, ambiguous)
+      assert.same(case.roots, xmlcontainment.roots(case.xml))
     end)
   end
 
@@ -128,42 +150,5 @@ describe('xmlcontainment', function()
     assert.same({ Leaf = true }, ambiguous)
     local actual = table.concat(chains.Leaf, '/')
     assert.same(true, actual == 'Frame/A/Leaf' or actual == 'Frame/B/Leaf')
-  end)
-
-  describe('roots', function()
-    it('finds a tag nothing else ever admits as a child', function()
-      local xml = {
-        Frame = { contents = { tags = { Leaf = true } } },
-        Leaf = {},
-      }
-      assert.same({ Frame = true }, xmlcontainment.roots(xml))
-    end)
-
-    it('excludes a tag reachable only via its extends chain', function()
-      local xml = {
-        Base = {},
-        Frame = { contents = { tags = { Base = true } } },
-        Sub = { extends = 'Base' },
-      }
-      assert.same({ Frame = true }, xmlcontainment.roots(xml))
-    end)
-
-    it('excludes a virtual tag even though nothing names it as a child', function()
-      local xml = {
-        Abstract = { virtual = true },
-        Frame = { contents = { tags = { Leaf = true } } },
-        Leaf = {},
-      }
-      assert.same({ Frame = true }, xmlcontainment.roots(xml))
-    end)
-
-    it('sealed stops extends-chain climbing, so the child stays a root', function()
-      local xml = {
-        Base = {},
-        Frame = { contents = { tags = { Base = true } } },
-        Sub = { extends = 'Base', sealed = true },
-      }
-      assert.same({ Frame = true, Sub = true }, xmlcontainment.roots(xml))
-    end)
   end)
 end)

--- a/spec/tools/xmlcontainment_spec.lua
+++ b/spec/tools/xmlcontainment_spec.lua
@@ -5,7 +5,6 @@ describe('xmlcontainment', function()
     ['finds a direct child'] = {
       xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
       chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
-      roots = { Frame = true },
     },
     ['walks through wrapper tags to find the shortest chain'] = {
       xml = {
@@ -18,7 +17,6 @@ describe('xmlcontainment', function()
         Wrap = { 'Frame', 'Wrap' },
         Leaf = { 'Frame', 'Wrap', 'Leaf' },
       },
-      roots = { Frame = true },
     },
     ['matches a tag reachable only via its extends chain'] = {
       xml = {
@@ -31,12 +29,10 @@ describe('xmlcontainment', function()
         Base = { 'Frame', 'Base' },
         Sub = { 'Frame', 'Sub' },
       },
-      roots = { Frame = true },
     },
     ['does not mark a tag reachable if nothing accepts it'] = {
       xml = { Frame = { contents = { tags = {} } }, Orphan = {} },
       chains = { Frame = { 'Frame' } },
-      roots = { Frame = true, Orphan = true },
     },
     ['sealed stops extends-chain climbing for containment purposes'] = {
       xml = {
@@ -45,7 +41,6 @@ describe('xmlcontainment', function()
         Sub = { extends = 'Base', sealed = true },
       },
       chains = { Frame = { 'Frame' }, Base = { 'Frame', 'Base' } },
-      roots = { Frame = true, Sub = true },
     },
     ['sealed does not affect a tag reachable via its own declared contents'] = {
       xml = {
@@ -54,16 +49,6 @@ describe('xmlcontainment', function()
         Sub = { extends = 'Base', sealed = true },
       },
       chains = { Frame = { 'Frame' }, Sub = { 'Frame', 'Sub' } },
-      roots = { Frame = true, Base = true },
-    },
-    ['excludes a virtual tag even though nothing names it as a child'] = {
-      xml = {
-        Abstract = { virtual = true },
-        Frame = { contents = { tags = { Leaf = true } } },
-        Leaf = {},
-      },
-      chains = { Frame = { 'Frame' }, Leaf = { 'Frame', 'Leaf' } },
-      roots = { Frame = true },
     },
     ['does not mark a tag ambiguous when a second route is strictly deeper'] = {
       xml = {
@@ -80,7 +65,6 @@ describe('xmlcontainment', function()
         B = { 'Frame', 'C', 'B' },
         Leaf = { 'Frame', 'A', 'Leaf' },
       },
-      roots = { Frame = true },
     },
     ['preferParent resolves a tie without marking it ambiguous'] = {
       xml = {
@@ -96,7 +80,6 @@ describe('xmlcontainment', function()
         B = { 'Frame', 'B' },
         Leaf = { 'Frame', 'B', 'Leaf' },
       },
-      roots = { Frame = true },
     },
     ['preferParent does not affect tags with only one candidate'] = {
       xml = {
@@ -110,17 +93,13 @@ describe('xmlcontainment', function()
         A = { 'Frame', 'A' },
         Leaf = { 'Frame', 'A', 'Leaf' },
       },
-      roots = { Frame = true },
     },
-    -- Neither tag is a root here: each is only ever legal nested inside the
-    -- other, so this schema fragment alone has no valid document root.
     ['rediscovers the root tag as an ordinary two-hop descendant of itself'] = {
       xml = {
         Frame = { contents = { tags = { Wrap = true } } },
         Wrap = { contents = { tags = { Frame = true } } },
       },
       chains = { Frame = { 'Frame', 'Wrap', 'Frame' }, Wrap = { 'Frame', 'Wrap' } },
-      roots = {},
     },
   }
 
@@ -129,7 +108,6 @@ describe('xmlcontainment', function()
       local chains, ambiguous = xmlcontainment.chains(case.xml, 'Frame', case.preferParent)
       assert.same(case.chains, chains)
       assert.same({}, ambiguous)
-      assert.same(case.roots, xmlcontainment.roots(case.xml))
     end)
   end
 
@@ -150,5 +128,57 @@ describe('xmlcontainment', function()
     assert.same({ Leaf = true }, ambiguous)
     local actual = table.concat(chains.Leaf, '/')
     assert.same(true, actual == 'Frame/A/Leaf' or actual == 'Frame/B/Leaf')
+  end)
+
+  describe('roots', function()
+    -- roots() has none of chains()'s BFS/shortest-path/tie-breaking
+    -- machinery -- it's a plain per-tag "is this ever a legal child of
+    -- anything" predicate, so it needs far fewer cases to cover: direct
+    -- containment, extends-based substitution, sealed truncating that
+    -- substitution, virtual overriding reachability, and the everything-
+    -- nests-in-everything-else edge case where no tag is a root at all.
+    local rootsCases = {
+      ['finds a tag nothing else ever admits as a child'] = {
+        xml = { Frame = { contents = { tags = { Leaf = true } } }, Leaf = {} },
+        roots = { Frame = true },
+      },
+      ['excludes a tag reachable only via its extends chain'] = {
+        xml = {
+          Base = {},
+          Frame = { contents = { tags = { Base = true } } },
+          Sub = { extends = 'Base' },
+        },
+        roots = { Frame = true },
+      },
+      ['sealed keeps a tag a root despite its base being accepted elsewhere'] = {
+        xml = {
+          Base = {},
+          Frame = { contents = { tags = { Base = true } } },
+          Sub = { extends = 'Base', sealed = true },
+        },
+        roots = { Frame = true, Sub = true },
+      },
+      ['excludes a virtual tag even though nothing names it as a child'] = {
+        xml = {
+          Abstract = { virtual = true },
+          Frame = { contents = { tags = { Leaf = true } } },
+          Leaf = {},
+        },
+        roots = { Frame = true },
+      },
+      ['has no roots when every tag is only ever legal nested in another'] = {
+        xml = {
+          Frame = { contents = { tags = { Wrap = true } } },
+          Wrap = { contents = { tags = { Frame = true } } },
+        },
+        roots = {},
+      },
+    }
+
+    for name, case in pairs(rootsCases) do
+      it(name, function()
+        assert.same(case.roots, xmlcontainment.roots(case.xml))
+      end)
+    end
   end)
 end)

--- a/tools/prep.lua
+++ b/tools/prep.lua
@@ -438,6 +438,7 @@ local xmlflat = (function()
       newtree[k:lower()] = {
         attributes = attrs,
         children = kids,
+        root = v.root,
         supertypes = supertypes,
         text = text,
         warnsinvalid = warnsinvalid,

--- a/tools/xmlcontainment.lua
+++ b/tools/xmlcontainment.lua
@@ -22,40 +22,42 @@
 -- tag is recorded in the second return value, `ambiguous`, the set of tags
 -- with no unique shortest path -- callers can then decide whether/when
 -- that matters for their own purposes.
+local function supertypesOf(xml, tag)
+  local st = { [tag:lower()] = true }
+  local t = xml[tag]
+  local climbing = not t.sealed
+  while t.extends do
+    if climbing then
+      st[t.extends:lower()] = true
+    end
+    t = xml[t.extends]
+    climbing = climbing and not t.sealed
+  end
+  return st
+end
+
+local function childrenOf(xml, tag)
+  local kids = {}
+  local t = xml[tag]
+  while true do
+    if t.contents and t.contents ~= 'text' then
+      for kid in pairs(t.contents.tags) do
+        kids[kid:lower()] = true
+      end
+    end
+    if not t.extends then
+      break
+    end
+    t = xml[t.extends]
+  end
+  return kids
+end
+
 local function chains(xml, root, preferParent)
-  local function supertypesOf(tag)
-    local st = { [tag:lower()] = true }
-    local t = xml[tag]
-    local climbing = not t.sealed
-    while t.extends do
-      if climbing then
-        st[t.extends:lower()] = true
-      end
-      t = xml[t.extends]
-      climbing = climbing and not t.sealed
-    end
-    return st
-  end
-  local function childrenOf(tag)
-    local kids = {}
-    local t = xml[tag]
-    while true do
-      if t.contents and t.contents ~= 'text' then
-        for kid in pairs(t.contents.tags) do
-          kids[kid:lower()] = true
-        end
-      end
-      if not t.extends then
-        break
-      end
-      t = xml[t.extends]
-    end
-    return kids
-  end
   local supertypes, children = {}, {}
   for tag in pairs(xml) do
-    supertypes[tag] = supertypesOf(tag)
-    children[tag] = childrenOf(tag)
+    supertypes[tag] = supertypesOf(xml, tag)
+    children[tag] = childrenOf(xml, tag)
   end
   local result = { [root] = { root } }
   local visited = {}
@@ -115,6 +117,40 @@ local function chains(xml, root, preferParent)
   return result, ambiguous
 end
 
+-- The set of non-virtual tags that are never a legal child of any other tag
+-- in the schema -- i.e. the tags that can legitimately stand as an XML
+-- document's root element. A virtual tag is excluded even when nothing
+-- names it as a child, since it can never be instantiated as a literal tag
+-- either way (it exists only for concrete subtypes to extend).
+local function roots(xml)
+  local children = {}
+  for tag in pairs(xml) do
+    children[tag] = childrenOf(xml, tag)
+  end
+  local result = {}
+  for tag in pairs(xml) do
+    if not xml[tag].virtual then
+      local isChild = false
+      for st in pairs(supertypesOf(xml, tag)) do
+        for _, kids in pairs(children) do
+          if kids[st] then
+            isChild = true
+            break
+          end
+        end
+        if isChild then
+          break
+        end
+      end
+      if not isChild then
+        result[tag] = true
+      end
+    end
+  end
+  return result
+end
+
 return {
   chains = chains,
+  roots = roots,
 }

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -44,6 +44,12 @@ end
 return function(datalua, eventqueue)
   local QueueEvent = eventqueue.QueueEvent
   local lang = datalua.xmlflat
+  local rootTags = {}
+  for k, v in pairs(lang) do
+    if v.root then
+      rootTags[k] = true
+    end
+  end
   local stringenums = datalua.stringenums
   local enums = datalua.globals.Enum
   local attributeTypes = {
@@ -198,10 +204,7 @@ return function(datalua, eventqueue)
         }
       end
     end
-    local result = run(root, 'toplevel', {
-      bindings = true,
-      ui = true,
-    })
+    local result = run(root, 'toplevel', rootTags)
     return result, warnings
   end
 


### PR DESCRIPTION
## Summary
- `wowless/modules/xml.lua` hardcoded `{ bindings = true, ui = true }` as the whitelist of legal XML document-root tags. Add an explicit `root` flag to `xml.yaml` tag definitions (mirroring the existing `sealed`/`virtual` flags), forward it through `xmlflat` in `prep.lua`, and have `xml.lua` build its whitelist from that instead.
- Add `tools.xmlcontainment.roots()`: the structural computation of which tags are never a legal child of any other tag. A spec (`spec/data/xml_spec.lua`) asserts, per product, that this exactly matches which tags are flagged `root` -- catching both a wrongly-flagged tag and a tag that silently becomes unreachable (and thus an accidental root) without being flagged.
- That spec caught a real pre-existing gap: `Value` is structurally identical to `Dimension`/`Insets` (an abstract `AbsValue`/`AbsDimension`/etc. wrapper, never itself a legal child) but was missing the `virtual: true` flag those two carry. Fixed alongside, across all 8 products.

## Test plan
- [x] `cmake --build --preset default --target test` (exit 0, no output)
- [x] `pre-commit run -a`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_0132bHoa1rGsPDnezMCj1nc3