### PR TITLE
api,xmleval,xml,errorhandler,mainloop: route all LUA_WARNING through a dedicated queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -921,8 +921,10 @@ lua2c(
   wowless.modules.uiobjecttypes=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/uiobjecttypes.lua
   wowless.modules.units=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/units.lua
   wowless.modules.visibility=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/visibility.lua
+  wowless.modules.warningqueue=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/warningqueue.lua
   wowless.modules.xml=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/xml.lua
   wowless.modules.xmleval=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/xmleval.lua
+  wowless.modules.xmlwarningqueue=${CMAKE_CURRENT_SOURCE_DIR}/wowless/modules/xmlwarningqueue.lua
   wowless.profiler=${CMAKE_CURRENT_SOURCE_DIR}/wowless/profiler.lua
   wowless.runner=${CMAKE_CURRENT_SOURCE_DIR}/wowless/runner.lua
   wowless.luaobject=c

--- a/data/modules.yaml
+++ b/data/modules.yaml
@@ -4,10 +4,10 @@ addons:
 api:
   deps:
     datalua:
-    events:
     intrinsics:
     templates:
     uiobjecttypes:
+    warningqueue:
     xmleval:
 atlas:
   deps:
@@ -49,9 +49,9 @@ env:
   deps:
 errorhandler:
   deps:
-    eventqueue:
     uiobjects:
     uiobjecttypes:
+    warningqueue:
 errors:
   deps:
     log:
@@ -112,7 +112,9 @@ mainloop:
     scripts:
     time:
     visibility:
+    warningqueue:
     xmleval:
+    xmlwarningqueue:
 maxErrors:
   root:
     default: '0'
@@ -182,18 +184,19 @@ units:
 visibility:
   deps:
     scripts:
+warningqueue:
+  deps:
+    events:
 xml:
   deps:
     datalua:
-    eventqueue:
+    xmlwarningqueue:
 xmleval:
   deps:
     bindings:
     cstubs:
     datalua:
     env:
-    eventqueue:
-    events:
     intrinsics:
     log:
     loglevel:
@@ -204,4 +207,9 @@ xmleval:
     uiobjects:
     uiobjecttypes:
     visibility:
+    warningqueue:
     xml:
+    xmlwarningqueue:
+xmlwarningqueue:
+  deps:
+    warningqueue:

--- a/spec/wowless/modules/xml_spec.lua
+++ b/spec/wowless/modules/xml_spec.lua
@@ -12,7 +12,7 @@ describe('xml', function()
   for _, p in ipairs(require('build.data.products')) do
     describe(p, function()
       local datalua = require('build.products.' .. p .. '.data')
-      local parse = xmlmodule(datalua, { QueueEvent = function() end })
+      local parse = xmlmodule(datalua, { QueueXmlWarning = function() end })
       -- ButtonText/NormalFont share a type (FontString/Font) with generic
       -- layered regions but belong to Button's own substitution group, not
       -- the generic one -- see issue #778.

--- a/wowless/modules/api.lua
+++ b/wowless/modules/api.lua
@@ -1,8 +1,8 @@
-return function(datalua, events, intrinsics, templates, uiobjecttypes, xmleval)
+return function(datalua, intrinsics, templates, uiobjecttypes, warningqueue, xmleval)
   local GetIntrinsic = intrinsics.Get
   local HasType = uiobjecttypes.Has
   local InheritsFrom = uiobjecttypes.InheritsFrom
-  local SendEvent = events.SendEvent
+  local QueueWarning = warningqueue.QueueWarning
 
   local function CreateFrame(type, name, parent, templateNames, id)
     local ltype = string.lower(type)
@@ -13,7 +13,7 @@ return function(datalua, events, intrinsics, templates, uiobjecttypes, xmleval)
     local nested = intrinsicEntry and intrinsicEntry.nested
     if nested or not HasType(basetype) or not InheritsFrom(basetype, 'frame') then
       if nested or datalua.config.runtime.warners[ltype] then
-        SendEvent('LUA_WARNING', 'Unknown frame type: ' .. type)
+        QueueWarning('Unknown frame type: ' .. type)
       end
       error('CreateFrame: Unknown frame type \'' .. type .. '\'', 0)
     end

--- a/wowless/modules/errorhandler.lua
+++ b/wowless/modules/errorhandler.lua
@@ -1,5 +1,5 @@
-return function(eventqueue, uiobjects, uiobjecttypes)
-  local QueueEvent = eventqueue.QueueEvent
+return function(uiobjects, uiobjecttypes, warningqueue)
+  local QueueWarning = warningqueue.QueueWarning
   local UserData = uiobjects.UserData
   local GetObjectType = uiobjecttypes.GetObjectType
   local currentFn
@@ -42,7 +42,7 @@ return function(eventqueue, uiobjects, uiobjecttypes)
       msg = SubstituteObjectName(msg)
     end
     if not pcall(currentFn, msg) then
-      QueueEvent('LUA_WARNING', msg)
+      QueueWarning(msg)
     end
   end)
 

--- a/wowless/modules/mainloop.lua
+++ b/wowless/modules/mainloop.lua
@@ -1,6 +1,8 @@
-return function(eventqueue, region, scripts, time, visibility, xmleval)
+return function(eventqueue, region, scripts, time, visibility, warningqueue, xmleval, xmlwarningqueue)
   local Advance = time.Advance
   local DrainEvents = eventqueue.DrainEvents
+  local DrainWarnings = warningqueue.DrainWarnings
+  local DumpXmlWarnings = xmlwarningqueue.Dump
   local frames = xmleval.frames
   local GetRect = region.GetRect
   local IsVisible = visibility.IsVisible
@@ -8,6 +10,8 @@ return function(eventqueue, region, scripts, time, visibility, xmleval)
 
   local function NextFrame(elapsed)
     DrainEvents()
+    DumpXmlWarnings()
+    DrainWarnings()
     Advance(elapsed)
     for frame in frames:entries() do
       if IsVisible(frame) then

--- a/wowless/modules/warningqueue.lua
+++ b/wowless/modules/warningqueue.lua
@@ -1,0 +1,20 @@
+return function(events)
+  local SendEvent = events.SendEvent
+  local pending = {}
+
+  local function QueueWarning(msg)
+    table.insert(pending, msg)
+  end
+
+  local function DrainWarnings()
+    for _, msg in ipairs(pending) do
+      SendEvent('LUA_WARNING', msg)
+    end
+    table.wipe(pending)
+  end
+
+  return {
+    DrainWarnings = DrainWarnings,
+    QueueWarning = QueueWarning,
+  }
+end

--- a/wowless/modules/xml.lua
+++ b/wowless/modules/xml.lua
@@ -41,8 +41,8 @@ local function xml2dom(xmlstr)
   return stack[1]._children[1]
 end
 
-return function(datalua, eventqueue)
-  local QueueEvent = eventqueue.QueueEvent
+return function(datalua, xmlwarningqueue)
+  local QueueXmlWarning = xmlwarningqueue.QueueXmlWarning
   local lang = datalua.xmlflat
   local rootTags = {}
   for k, v in pairs(lang) do
@@ -107,9 +107,9 @@ return function(datalua, eventqueue)
     -- children and attributes rather than dropping the whole subtree
     -- silently, flagging each one individually too.
     local function warnUnrecognized(e)
-      QueueEvent('LUA_WARNING', ('Unrecognized XML: %s'):format(e._name))
+      QueueXmlWarning(('Unrecognized XML: %s'):format(e._name))
       for _, k in ipairs(e._attr) do
-        QueueEvent('LUA_WARNING', ('Unrecognized XML attribute: %s'):format(k))
+        QueueXmlWarning(('Unrecognized XML attribute: %s'):format(k))
       end
       for _, kid in ipairs(e._children or {}) do
         if kid._type == 'ELEMENT' then
@@ -149,7 +149,7 @@ return function(datalua, eventqueue)
           local vv = dispatch(attributeTypes, attr, v)
           if vv == nil then
             if ty.warnsinvalid[an] then
-              QueueEvent('LUA_WARNING', ('%s %s: Invalid %s value: %s'):format(e._name, nameOf(e), k, v))
+              QueueXmlWarning(('%s %s: Invalid %s value: %s'):format(e._name, nameOf(e), k, v))
             end
             table.insert(warnings, 'attribute ' .. k .. ' has invalid value ' .. v)
           else

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -9,8 +9,6 @@ return function(
   cstubs,
   datalua,
   envmodule,
-  eventqueue,
-  events,
   intrinsics,
   log,
   loglevel,
@@ -21,12 +19,14 @@ return function(
   uiobjects,
   uiobjecttypes,
   visibility,
-  xml
+  warningqueue,
+  xml,
+  xmlwarningqueue
 )
   local genv = envmodule.genv
   local secureenv = envmodule.secureenv
-  local QueueEvent = eventqueue.QueueEvent
-  local SendEvent = events.SendEvent
+  local QueueWarning = warningqueue.QueueWarning
+  local QueueXmlWarning = xmlwarningqueue.QueueXmlWarning
   local parseXml = xml
   local bindings = bindingsmodule.bindings
   local securemixins = {}
@@ -250,7 +250,7 @@ return function(
     if not scripts.HasScript(obj, script.type) then
       local prefix = datalua.config.runtime.bareScriptWarning and '' or 'Frame '
       local fmt = prefix .. '%s: Unknown script element %s'
-      SendEvent('LUA_WARNING', fmt:format(uiobjecttypes.GetObjectType(obj), script.name))
+      QueueWarning(fmt:format(uiobjecttypes.GetObjectType(obj), script.name))
       return
     end
     local fn
@@ -333,7 +333,7 @@ return function(
   -- enableSourceLocationLookup cvar is on. The addon forces it off
   -- (init.lua) so both sides can just compare bare messages.
   local function anchorWarning(parent, reason, value)
-    QueueEvent('LUA_WARNING', ('%s: %s: %s'):format(parent.name or 'Unknown', reason, value))
+    QueueXmlWarning(('%s: %s: %s'):format(parent.name or 'Unknown', reason, value))
   end
 
   local xmllang = {
@@ -741,7 +741,7 @@ return function(
           -- intrinsic fine, but refuses to instantiate it, the same way it
           -- warns on an unknown frame type.
           if intrinsicEntry and intrinsicEntry.nested then
-            QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. intrinsicEntry.displayName)
+            QueueXmlWarning('Unknown frame type: ' .. intrinsicEntry.displayName)
             return nil
           end
           -- issue #863: this tag parses (structurally valid per xml.yaml)
@@ -749,7 +749,7 @@ return function(
           -- client refuses to instantiate it, the same way it does an
           -- unknown frame type passed to CreateFrame.
           if unknownType then
-            QueueEvent('LUA_WARNING', 'Unknown frame type: ' .. e.name)
+            QueueXmlWarning('Unknown frame type: ' .. e.name)
             return nil
           end
           local name = e.attr.name

--- a/wowless/modules/xmlwarningqueue.lua
+++ b/wowless/modules/xmlwarningqueue.lua
@@ -1,0 +1,20 @@
+return function(warningqueue)
+  local QueueWarning = warningqueue.QueueWarning
+  local pending = {}
+
+  local function QueueXmlWarning(msg)
+    table.insert(pending, msg)
+  end
+
+  local function Dump()
+    for _, msg in ipairs(pending) do
+      QueueWarning(msg)
+    end
+    table.wipe(pending)
+  end
+
+  return {
+    Dump = Dump,
+    QueueXmlWarning = QueueXmlWarning,
+  }
+end


### PR DESCRIPTION
## Summary
- Real-client testing (this session) confirms every `LUA_WARNING` is queued for next-frame delivery — none fire inline — and that it fires *after* a frame's other queued events (which share `eventqueue.lua`'s `pending` list with `CHAT_MSG_SYSTEM`/`TIME_PLAYED_MSG`). `CreateFrame`'s "Unknown frame type" and `bindScript`'s "Unknown script element" were the last two sites still using `SendEvent`/the shared `eventqueue`.
- Adds a `warningqueue` module (`QueueWarning`/`DrainWarnings`) that every `LUA_WARNING` site now routes through, drained by `mainloop` right after the normal event queue.
- XML-structural-parse warnings (`xml.lua`) and XML-declarative-tag warnings (`xmleval.lua`'s anchor resolution and bare/nested-intrinsic unknown-frame-type) go through a separate `xmlwarningqueue` that `mainloop` dumps into `warningqueue` once per frame, ahead of the drain — keeping their real-client-confirmed "queued per-frame, not per-addon-load" batching distinct from warnings raised by an actual Lua call (`CreateFrame`, `bindScript`), which still enqueue directly.

## Note on history
This supersedes/corrects the direction of PR #882 (closed, reverted same day after real-client testing disproved a naive single-flat-queue model — see that PR's discussion). This PR is based on new, more detailed real-client findings from this session and adds the two-queue split (direct vs. XML-staged) that PR #882 was missing. **This has not been independently re-verified against a real client by me** — it relies on the findings reported in this session. Recommend a real-client pass (same method as PR #882) before merging, given the history here.

## Test plan
- [x] `cmake --build --preset default --target test` (clean run, no output, exit 0)
- [x] `pre-commit run -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162wBDkhFLzUjDVKEjQ4YYo