### PR TITLE
addon,generatexmltest: rename ExpectedNextFrame to ExpectedXmlWarnings

### DIFF
--- a/addon/Wowless/evenmoreintrinsic2.xml
+++ b/addon/Wowless/evenmoreintrinsic2.xml
@@ -1,6 +1,6 @@
 <Ui>
   <Script>
-    table.insert(_G.Wowless.ExpectedNextFrame, 'Unknown frame type: WowlessEvenMoreIntrinsicType')
+    table.insert(_G.Wowless.ExpectedXmlWarnings, 'Unknown frame type: WowlessEvenMoreIntrinsicType')
   </Script>
   <WowlessEvenMoreIntrinsicType />
 </Ui>

--- a/addon/Wowless/init.lua
+++ b/addon/Wowless/init.lua
@@ -22,17 +22,21 @@ end)
 G.LuaWarningsFrame = frame
 G.testsuite = {}
 
--- Mirrors QueueEvent/DrainEvents: some LUA_WARNINGs (XML-time issues
--- like anchor resolution or unrecognized elements) are queued and only
--- delivered at the start of the next frame, not fired inline. Tests for
--- those register into ExpectedNextFrame instead of ExpectedLuaWarnings
--- directly; a single After(0) call moves the whole batch across at
--- once, since ordering among multiple After(0) callbacks isn't
--- guaranteed.
-G.ExpectedNextFrame = {}
+-- Mirrors wowless's own warningqueue/xmlwarningqueue split: every
+-- LUA_WARNING is queued for next-frame delivery, none fire inline, so
+-- that alone isn't a reason to track two buckets. The real distinction
+-- is XML-time warnings (like anchor resolution or unrecognized
+-- elements), which stage separately and only get dumped into the main
+-- warning queue once a frame has passed, versus warnings from an
+-- actual Lua call (CreateFrame, bindScript), which queue directly.
+-- Tests for the former register into ExpectedXmlWarnings instead of
+-- ExpectedLuaWarnings directly; a single After(0) call moves the whole
+-- batch across at once, since ordering among multiple After(0)
+-- callbacks isn't guaranteed.
+G.ExpectedXmlWarnings = {}
 _G.C_Timer.After(0, function()
-  for _, v in ipairs(G.ExpectedNextFrame) do
+  for _, v in ipairs(G.ExpectedXmlWarnings) do
     table.insert(G.ExpectedLuaWarnings, v)
   end
-  table.wipe(G.ExpectedNextFrame)
+  table.wipe(G.ExpectedXmlWarnings)
 end)

--- a/addon/Wowless/test.xml
+++ b/addon/Wowless/test.xml
@@ -9,7 +9,7 @@
   <Script>
     for _, cfg in pairs(_G.WowlessData.Templates) do
       if cfg.warning then
-        table.insert(Wowless.ExpectedNextFrame, cfg.warning)
+        table.insert(Wowless.ExpectedXmlWarnings, cfg.warning)
       end
     end
   </Script>
@@ -25,7 +25,7 @@
   <Script>
     for tag, def in Wowless.sorted(_G.WowlessData.Xml) do
       if def.impl == 'unknowntype' then
-        table.insert(Wowless.ExpectedNextFrame, 'Unknown frame type: ' .. tag)
+        table.insert(Wowless.ExpectedXmlWarnings, 'Unknown frame type: ' .. tag)
       end
     end
   </Script>
@@ -216,14 +216,14 @@
     </Scripts>
   </WowlessIntrinsicType>
   <Script>
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: WowlessIntrinsicType')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: Scripts')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: OnLoad')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: WowlessIntrinsicType')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML attribute: name')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML attribute: intrinsic')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: Scripts')
-    table.insert(Wowless.ExpectedNextFrame, 'Unrecognized XML: OnLoad')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML: WowlessIntrinsicType')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML: Scripts')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML: OnLoad')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML: WowlessIntrinsicType')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML attribute: name')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML attribute: intrinsic')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML: Scripts')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unrecognized XML: OnLoad')
   </Script>
   <Include file='evenmoreintrinsic.xml' />
   <Script>
@@ -974,7 +974,7 @@
   </Frame>
   <Script>
     table.insert(
-      Wowless.ExpectedNextFrame,
+      Wowless.ExpectedXmlWarnings,
       "Unknown: Couldn't find relative frame: thisisdefinitelynotsomethingin_G"
     )
   </Script>
@@ -985,7 +985,7 @@
     </Anchors>
   </Frame>
   <Script>
-    table.insert(Wowless.ExpectedNextFrame, 'WowlessSelfAnchor: anchored to itself: WowlessSelfAnchor')
+    table.insert(Wowless.ExpectedXmlWarnings, 'WowlessSelfAnchor: anchored to itself: WowlessSelfAnchor')
   </Script>
   <Script>
     Wowless.check1(0, WowlessSelfAnchor:GetNumPoints())
@@ -1055,7 +1055,7 @@
     </Frames>
   </Frame>
   <Script>
-    table.insert(Wowless.ExpectedNextFrame, 'Unknown: anchored to itself: anyoldgarbage$parent.foo')
+    table.insert(Wowless.ExpectedXmlWarnings, 'Unknown: anchored to itself: anyoldgarbage$parent.foo')
   </Script>
 
   <Frame>

--- a/tools/generatexmltest.lua
+++ b/tools/generatexmltest.lua
@@ -85,7 +85,7 @@ local content = {
             local fmt = prefix .. 'ModelSceneActor: Unknown script element %%s'
             table.insert(_G.Wowless.ExpectedLuaWarnings, fmt:format(k))
           else
-            table.insert(_G.Wowless.ExpectedNextFrame, 'Unrecognized XML: ' .. k)
+            table.insert(_G.Wowless.ExpectedXmlWarnings, 'Unrecognized XML: ' .. k)
           end
         end
         assertEquals(table.concat(expected, ','), table.concat(WowlessLog, ','))


### PR DESCRIPTION
## Summary
- Follow-up to #884: since all `LUA_WARNING` is now queued for next-frame delivery in the real implementation (none fire inline), "next frame" was never the axis that should have distinguished the test addon's two expectation buckets.
- The actual distinction, matching #884's `warningqueue`/`xmlwarningqueue` split, is XML-time warnings (structural parse, anchor resolution) -- which stage separately and only merge into the main warning queue once a frame has passed -- versus warnings from an actual Lua call (`CreateFrame`, `bindScript`), which queue directly.
- Renames `ExpectedNextFrame` to `ExpectedXmlWarnings` everywhere (`init.lua`, `test.xml`, `evenmoreintrinsic2.xml`, `generatexmltest.lua`) and rewrites `init.lua`'s explanatory comment to match. No production code changes -- test vocabulary only.

## Test plan
- [x] `cmake --build --preset default --target test` (clean run, no output, exit 0)
- [x] `pre-commit run -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162wBDkhFLzUjDVKEjQ4YYo