### PR TITLE
warningqueue: cap LUA_WARNING delivery at 100 per frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1170,6 +1170,7 @@ set(specs
     spec/wowless/blp_spec.lua
     spec/wowless/bubblewrap_spec.lua
     spec/wowless/hlist_spec.lua
+    spec/wowless/modules/warningqueue_spec.lua
     spec/wowless/modules/xml_spec.lua
     spec/wowless/sqlite_spec.lua
     spec/wowless/toc_spec.lua

--- a/spec/wowless/modules/warningqueue_spec.lua
+++ b/spec/wowless/modules/warningqueue_spec.lua
@@ -1,0 +1,44 @@
+describe('warningqueue', function()
+  local warningqueuemodule = require('wowless.modules.warningqueue')
+  local function mkqueue()
+    local sent = {}
+    local queue = warningqueuemodule({
+      SendEvent = function(event, msg)
+        table.insert(sent, { event = event, msg = msg })
+      end,
+    })
+    return queue, sent
+  end
+
+  it('delivers everything under the per-frame cap', function()
+    local queue, sent = mkqueue()
+    queue.QueueWarning('a')
+    queue.QueueWarning('b')
+    queue.DrainWarnings()
+    assert.same({
+      { event = 'LUA_WARNING', msg = 'a' },
+      { event = 'LUA_WARNING', msg = 'b' },
+    }, sent)
+  end)
+
+  it('drops everything past the 100th warning queued in one frame', function()
+    local queue, sent = mkqueue()
+    for i = 1, 150 do
+      queue.QueueWarning(tostring(i))
+    end
+    queue.DrainWarnings()
+    assert.equals(100, #sent)
+    assert.equals('1', sent[1].msg)
+    assert.equals('100', sent[100].msg)
+  end)
+
+  it('does not carry dropped warnings over to the next frame', function()
+    local queue, sent = mkqueue()
+    for i = 1, 150 do
+      queue.QueueWarning(tostring(i))
+    end
+    queue.DrainWarnings()
+    queue.DrainWarnings()
+    assert.equals(100, #sent)
+  end)
+end)

--- a/wowless/modules/warningqueue.lua
+++ b/wowless/modules/warningqueue.lua
@@ -1,3 +1,8 @@
+-- A real client delivers at most this many LUA_WARNINGs per frame;
+-- anything past that in the same frame's drain is silently dropped, not
+-- carried over to the next one (client-verified).
+local maxWarningsPerFrame = 100
+
 return function(events)
   local SendEvent = events.SendEvent
   local pending = {}
@@ -7,8 +12,8 @@ return function(events)
   end
 
   local function DrainWarnings()
-    for _, msg in ipairs(pending) do
-      SendEvent('LUA_WARNING', msg)
+    for i = 1, math.min(#pending, maxWarningsPerFrame) do
+      SendEvent('LUA_WARNING', pending[i])
     end
     table.wipe(pending)
   end


### PR DESCRIPTION
## Summary
- A real client silently drops `LUA_WARNING`s past the 100th queued within a single frame's drain, rather than delivering them or carrying them over to the next frame — client-verified against `wow_classic_era` while investigating a mismatch surfaced by an in-progress addon-level XML containment test that queues well over 100 warnings from one document.
- `wowless/modules/warningqueue.lua`'s `DrainWarnings` previously delivered everything queued, unbounded, so wowless's own simulation couldn't reproduce this divergence without an actual client run.
- Adds a `maxWarningsPerFrame = 100` cap: `DrainWarnings` now sends at most the first 100 pending warnings per call and always wipes the full pending list afterward (matching the real client's drop-not-carry-over behavior for anything past the cap).
- Adds `spec/wowless/modules/warningqueue_spec.lua` covering: under-cap delivery, over-cap truncation to exactly the first 100 (in order), and that dropped warnings don't reappear on a later drain.

## Test plan
- [x] `cmake --build --preset default --target test` (clean run, no output, exit 0)
- [x] `pre-commit run -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_ce36080b