### PR TITLE
visibility: cache region visibility as a bit instead of walking parents

### DIFF
--- a/wowless/modules/uiobjects.lua
+++ b/wowless/modules/uiobjects.lua
@@ -23,7 +23,10 @@ return function(parentkey, uiobjecttypes, visibility)
   }
 
   local function DoSetParent(obj, parent)
-    if obj.parent == parent then
+    -- The `visible` check makes this fire only once at creation for the
+    -- common case of a nil-parent object, so `visible` still gets its
+    -- initial value even though `parent` didn't change from its default.
+    if obj.parent == parent and obj.visible ~= nil then
       return
     end
     local field = GetChildField(obj.type)
@@ -40,6 +43,7 @@ return function(parentkey, uiobjecttypes, visibility)
     if parent then
       parent[field]:insert(obj)
     end
+    obj.visible = obj.shown and IsVisible(parent)
     if parent and parent.frameLevel and obj.frameLevel and not obj.hasFixedFrameLevel then
       obj:SetFrameLevel(parent.frameLevel + 1)
     end
@@ -94,15 +98,11 @@ return function(parentkey, uiobjecttypes, visibility)
       end
       p = p.parent
     end
-    if obj.shown then
-      local opv = IsVisible(obj.parent)
-      local npv = IsVisible(parent)
-      DoSetParent(obj, parent)
-      if opv ~= npv then
-        UpdateVisible(obj, npv)
-      end
-    else
-      DoSetParent(obj, parent)
+    local wasVisible = IsVisible(obj)
+    DoSetParent(obj, parent)
+    local isVisible = IsVisible(obj)
+    if wasVisible ~= isVisible then
+      UpdateVisible(obj, isVisible)
     end
   end
 

--- a/wowless/modules/visibility.lua
+++ b/wowless/modules/visibility.lua
@@ -1,46 +1,62 @@
 return function(scripts)
   local RunScript = scripts.RunScript
 
+  -- `visible` is a cached bit kept up to date by SetShown/SetParent below,
+  -- rather than recomputed by walking the parent chain on every call.
   local function IsVisible(obj)
-    while obj do
-      if not obj.shown then
-        return false
+    return obj == nil or obj.visible
+  end
+
+  -- Every affected descendant's cached bit must be updated before any of
+  -- their OnShow/OnHide scripts fire, so a handler on one branch always
+  -- sees the final state of every other branch. So this runs as two
+  -- passes: first refresh `visible` across the whole affected subtree,
+  -- then fire scripts in the original per-node-recursive order.
+  local function SetVisibleBits(obj, visible)
+    obj.visible = visible
+    if obj.children then
+      for kid in obj.regions:entries() do
+        if kid.shown then
+          kid.visible = visible
+        end
       end
-      obj = obj.parent
+      for kid in obj.children:entries() do
+        if kid.shown then
+          SetVisibleBits(kid, visible)
+        end
+      end
     end
-    return true
   end
 
   -- Regions can't have their own children or regions, so their scripts
-  -- fire directly rather than recursing; only frames reach this function.
-  local function DoUpdateVisible(frame, script)
-    for kid in frame.regions:entries() do
-      if kid.shown then
-        RunScript(kid, script)
+  -- fire directly rather than recursing; only frames recurse further.
+  local function FireVisibleScripts(obj, script)
+    if obj.children then
+      for kid in obj.regions:entries() do
+        if kid.shown then
+          RunScript(kid, script)
+        end
+      end
+      for kid in obj.children:entries() do
+        if kid.shown then
+          FireVisibleScripts(kid, script)
+        end
       end
     end
-    for kid in frame.children:entries() do
-      if kid.shown then
-        DoUpdateVisible(kid, script)
-      end
-    end
-    RunScript(frame, script)
+    RunScript(obj, script)
   end
 
   local function UpdateVisible(obj, visible)
-    local script = visible and 'OnShow' or 'OnHide'
-    if obj.children then
-      DoUpdateVisible(obj, script)
-    else
-      RunScript(obj, script)
-    end
+    SetVisibleBits(obj, visible)
+    FireVisibleScripts(obj, visible and 'OnShow' or 'OnHide')
   end
 
   local function SetShown(obj, shown)
     if obj.shown ~= shown then
       obj.shown = shown
-      if IsVisible(obj.parent) then
-        UpdateVisible(obj, shown)
+      local visible = shown and IsVisible(obj.parent)
+      if visible ~= obj.visible then
+        UpdateVisible(obj, visible)
       end
     end
   end

--- a/wowless/modules/xmleval.lua
+++ b/wowless/modules/xmleval.lua
@@ -533,6 +533,7 @@ return function(
   local xmlattrlang = {
     hidden = function(_, obj, value)
       obj.shown = not value
+      obj.visible = obj.shown and IsVisible(obj.parent)
     end,
     mixin = function(ctx, obj, value)
       local env = ctx.useAddonEnv and ctx.addonEnv or ctx.useSecureEnv and secureenv or genv


### PR DESCRIPTION
IsVisible() used to recompute a region's effective visibility on every
call by walking up the parent chain checking `shown` at each level.
Instead, maintain a `visible` field on each object, kept correct
incrementally wherever `shown` or `parent` change (SetShown,
SetParent/DoSetParent, and the XML `hidden` attribute handler), so
IsVisible() becomes an O(1) field read.

Visibility propagation to descendants during a show/hide now runs as
two passes: refresh every affected descendant's cached bit first, then
fire OnShow/OnHide scripts in the original order. This preserves the
existing guarantee that a script on one branch always observes the
final visibility of every other branch, not a value from mid-update.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
